### PR TITLE
Improve error messages for spawned processes

### DIFF
--- a/lib/kite-process-error.js
+++ b/lib/kite-process-error.js
@@ -1,0 +1,10 @@
+'use strict';
+
+module.exports = class KiteProcessError extends Error {
+  constructor(type, data) {
+    super(type);
+    this.data = data;
+    this.message = data.message;
+    Error.captureStackTrace(this, this.constructor);
+  }
+};

--- a/lib/support/osx.js
+++ b/lib/support/osx.js
@@ -83,7 +83,11 @@ const OSXSupport = {
   },
 
   isKiteInstalled() {
-    return utils.spawnPromise('mdfind', ['kMDItemCFBundleIdentifier = "com.kite.Kite"'])
+    return utils.spawnPromise(
+      'mdfind',
+      ['kMDItemCFBundleIdentifier = "com.kite.Kite"'],
+      'mdfind_error',
+      'Unable to run mdfind and verify that Kite is installed')
     .then(res => {
       if (!res || res.trim() === '') {
         throw new KiteError('bad_state', STATES.UNINSTALLED);
@@ -110,7 +114,11 @@ const OSXSupport = {
   },
 
   isKiteEnterpriseInstalled() {
-    return utils.spawnPromise('mdfind', ['kMDItemCFBundleIdentifier = "enterprise.kite.Kite"'])
+    return utils.spawnPromise(
+      'mdfind',
+      ['kMDItemCFBundleIdentifier = "enterprise.kite.Kite"'],
+      'mdfind_error',
+      'Unable to run mdfind and verify that kite enterprise is installed')
     .then(res => {
       if (!res || res.trim() === '') {
         throw new KiteError('bad_state', STATES.UNINSTALLED);
@@ -161,21 +169,28 @@ const OSXSupport = {
     opts = opts || {};
 
     utils.guardCall(opts.onInstallStart);
-    return utils.spawnPromise('hdiutil', [
-      'attach', '-nobrowse', this.KITE_DMG_PATH,
-    ], 'mount_error')
+    return utils.spawnPromise(
+      'hdiutil',
+      ['attach', '-nobrowse', this.KITE_DMG_PATH],
+      'mount_error',
+      'Unable to mount Kite.dmg')
     .then(() => utils.guardCall(opts.onMount))
-    .then(() => utils.spawnPromise('cp', [
-      '-r', this.KITE_APP_PATH.mounted, this.APPS_PATH,
-    ], 'cp_error'))
+    .then(() => utils.spawnPromise(
+      'cp',
+      ['-r', this.KITE_APP_PATH.mounted, this.APPS_PATH],
+      'cp_error',
+      'Unable to copy Kite.app in the applications directory'))
     .then(() => utils.guardCall(opts.onCopy))
-    .then(() => utils.spawnPromise('hdiutil', [
-      'detach', this.KITE_VOLUME_PATH,
-    ], 'unmount_error'))
+    .then(() => utils.spawnPromise(
+      'hdiutil',
+      ['detach', this.KITE_VOLUME_PATH],
+      'unmount_error',
+      'Unable to unmount Kite.dmg'))
     .then(() => utils.guardCall(opts.onUnmount))
-    .then(() => utils.spawnPromise('rm', [
-      this.KITE_DMG_PATH,
-    ], 'rm_error'))
+    .then(() => utils.spawnPromise(
+      'rm', [this.KITE_DMG_PATH],
+      'rm_error',
+      'Unable to remove Kite.dmg'))
     .then(() => utils.guardCall(opts.onRemove))
     // mdfind takes some time to index the app location, so we need to
     // wait for the install to fully complete. Runs 10 times at 1.5s
@@ -184,11 +199,12 @@ const OSXSupport = {
   },
 
   isKiteRunning() {
-    return utils.spawnPromise('/bin/ps', [
-      '-axco', 'command',
-    ], {
-      encoding: 'utf8',
-    }, 'ps_error')
+    return utils.spawnPromise(
+      '/bin/ps',
+      ['-axco', 'command'],
+      {encoding: 'utf8'},
+      'ps_error',
+      'Unable to run the ps command and verify that Kite is running')
     .then(stdout => {
       const procs = stdout.split('\n');
       if (!procs.some(s => /^Kite$/.test(s))) {
@@ -199,19 +215,22 @@ const OSXSupport = {
 
   runKite() {
     return this.isKiteRunning()
-    .catch(() => utils.spawnPromise('defaults', [
-      'write', 'com.kite.Kite', 'shouldReopenSidebar', '0',
-    ])
+    .catch(() => utils.spawnPromise(
+      'defaults',
+      ['write', 'com.kite.Kite', 'shouldReopenSidebar', '0'],
+      'defaults_error',
+      'Unable to run defaults command')
     .then(() =>
     utils.spawnPromise('open', ['-a', this.installPath, '--args', '"--plugin-launch"'])));
   },
 
   isKiteEnterpriseRunning() {
-    return utils.spawnPromise('/bin/ps', [
-      '-axco', 'command',
-    ], {
-      encoding: 'utf8',
-    }, 'ps_error')
+    return utils.spawnPromise(
+      '/bin/ps',
+      ['-axco', 'command'],
+      {encoding: 'utf8'},
+      'ps_error',
+      'Unable to run the ps command and verify that Kite enterprise is running')
     .then(stdout => {
       const procs = stdout.split('\n');
       if (!procs.some(s => /^KiteEnterprise$/.test(s))) {
@@ -221,9 +240,11 @@ const OSXSupport = {
   },
 
   runKiteEnterprise() {
-    return utils.spawnPromise('defaults', [
-      'write', 'enterprise.kite.Kite', 'shouldReopenSidebar', '0',
-    ])
+    return utils.spawnPromise(
+      'defaults',
+      ['write', 'enterprise.kite.Kite', 'shouldReopenSidebar', '0'],
+      'defaults_error',
+      'Unable to run defaults command')
     .then(() =>
       utils.spawnPromise('open', ['-a', this.enterpriseInstallPath]));
   },

--- a/lib/support/windows.js
+++ b/lib/support/windows.js
@@ -177,14 +177,21 @@ const WindowsSupport = {
     env.KITE_SKIP_ONBOARDING = '1';
 
     utils.guardCall(opts.onInstallStart);
-    return utils.execPromise(this.KITE_INSTALLER_PATH + ' --skip-onboarding --plugin-launch', {env: env})
+    return utils.execPromise(
+      this.KITE_INSTALLER_PATH + ' --skip-onboarding --plugin-launch',
+      {env: env},
+      'kite_install_error',
+      'Unable to run Kite installer')
     .then(() => utils.guardCall(opts.onCopy))
     .then(() => fs.unlinkSync(this.KITE_INSTALLER_PATH))
     .then(() => utils.guardCall(opts.onRemove));
   },
 
   isKiteRunning() {
-    return utils.spawnPromise('tasklist', 'tasklist_error')
+    return utils.spawnPromise(
+      'tasklist',
+      'tasklist_error',
+      'Unable to run the tasklist command and verify whether kite is running or not')
     .then(stdout => {
       const procs = stdout.split('\n');
       if (procs.every(l => l.indexOf('kited.exe') === -1)) {
@@ -199,7 +206,11 @@ const WindowsSupport = {
       var env = Object.create(process.env);
       env.KITE_SKIP_ONBOARDING = '1';
 
-      return utils.spawnPromise(this.KITE_EXE_PATH, {detached: true, env: env});
+      return utils.spawnPromise(
+        this.KITE_EXE_PATH,
+        [], {detached: true, env: env},
+        'kite_exe_error',
+        'Unable to run kite executable');
     });
 
   },

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,6 +4,7 @@ const http = require('http');
 const https = require('https');
 const child_process = require('child_process');
 const KiteError = require('./kite-error');
+const KiteProcessError = require('./kite-process-error');
 
 function deepMerge(a, b) {
   a = JSON.parse(JSON.stringify(a || {}));
@@ -170,19 +171,25 @@ function retryPromise(doAttempt, attempts, interval) {
 // Spawns a child process and returns a promise that will be resolved if
 // the process ends with a code of 0, otherwise the promise will be rejected
 // with an error object of the provided rejectionType.
-function spawnPromise(cmd, cmdArgs, cmdOptions, rejectionType) {
+function spawnPromise(cmd, cmdArgs, cmdOptions, rejectionType, rejectionMessage) {
   const args = [cmd];
 
   if (cmdArgs) {
-    typeof cmdArgs === 'string'
-      ? rejectionType = cmdArgs
-      : args.push(cmdArgs);
+    if (typeof cmdArgs === 'string') {
+      rejectionType = cmdArgs;
+      rejectionMessage = cmdOptions;
+    } else {
+      args.push(cmdArgs);
+    }
   }
 
   if (cmdOptions) {
-    typeof cmdOptions === 'string'
-      ? rejectionType = cmdOptions
-      : args.push(cmdOptions);
+    if (typeof cmdOptions === 'string') {
+      rejectionMessage = rejectionType;
+      rejectionType = cmdOptions;
+    } else {
+      args.push(cmdOptions);
+    }
   }
 
   return new Promise((resolve, reject) => {
@@ -195,7 +202,14 @@ function spawnPromise(cmd, cmdArgs, cmdOptions, rejectionType) {
 
     proc.on('close', code => {
       code
-        ? reject({ type: rejectionType, data: stderr })
+        ? reject(new KiteProcessError(rejectionType,
+          {
+            message: rejectionMessage,
+            stderr,
+            stdout,
+            cmd: `${cmd} ${(typeof cmdOptions != 'string' ? cmdArgs || [] : []).join(' ')}`,
+            options: typeof cmdOptions != 'string' ? cmdOptions : undefined,
+          }))
         : resolve(stdout);
     });
   });


### PR DESCRIPTION
It introduces a new Error object that carries information about the failed command (command + args).

Kite installer will be able to consume these errors to report them to rollbar