### PR TITLE
Add support for multipart form data in both node and browser clients

### DIFF
--- a/lib/clients/browser.js
+++ b/lib/clients/browser.js
@@ -62,10 +62,6 @@ module.exports = class BrowserClient {
       }
 
       if (opts.headers) {
-        for (const header in opts.headers) {
-          query.setRequestHeader(header, opts.headers[header]);
-        }
-
         if (opts.headers['Content-Type'] === 'multipart/form-data' ||
             opts.headers['content-type'] === 'multipart/form-data') {
           delete opts.headers['Content-Type'];
@@ -77,6 +73,10 @@ module.exports = class BrowserClient {
             form.append(key, data[key]);
           }
           data = form;
+        }
+
+        for (const header in opts.headers) {
+          query.setRequestHeader(header, opts.headers[header]);
         }
       }
       if (!opts.headers || !opts.headers['Cache-Control']) {

--- a/lib/clients/browser.js
+++ b/lib/clients/browser.js
@@ -66,6 +66,18 @@ module.exports = class BrowserClient {
           query.setRequestHeader(header, opts.headers[header]);
         }
 
+        if (opts.headers['Content-Type'] === 'multipart/form-data' ||
+            opts.headers['content-type'] === 'multipart/form-data') {
+          delete opts.headers['Content-Type'];
+          delete opts.headers['content-type'];
+
+          const form = new FormData();
+
+          for (const key in data) {
+            form.append(key, data[key]);
+          }
+          data = form;
+        }
       }
       if (!opts.headers || !opts.headers['Cache-Control']) {
         query.setRequestHeader('Cache-Control', 'no-cache, must-revalidate');

--- a/lib/clients/node.js
+++ b/lib/clients/node.js
@@ -2,6 +2,7 @@
 
 const http = require('http');
 const https = require('https');
+const FormData = require('form-data');
 
 const utils = require('../utils');
 
@@ -16,11 +17,30 @@ module.exports = class NodeClient {
 
   request(opts, data, timeout) {
     return new Promise((resolve, reject) => {
+      let form;
+
       opts.hostname = this.hostname;
       if (this.port > 0) { opts.port = this.port; }
       opts.path = this.base + opts.path;
       opts.headers = opts.headers || {};
       this.writeCookies(opts.headers);
+
+      if (opts.headers['Content-Type'] === 'multipart/form-data' ||
+          opts.headers['content-type'] === 'multipart/form-data') {
+        delete opts.headers['Content-Type'];
+        delete opts.headers['content-type'];
+
+        form = new FormData();
+        for (const key in data) {
+          form.append(key, data[key]);
+        }
+
+        const headers = form.getHeaders();
+        for (const key in headers) {
+          opts.headers[key] = headers[key];
+        }
+      }
+
       const req = this.protocol.request(opts, resp => {
         this.readCookies(resp);
         resolve(resp);
@@ -29,8 +49,12 @@ module.exports = class NodeClient {
       if (timeout != null) {
         req.setTimeout(timeout, () => reject(new Error('timeout')));
       }
-      if (data) { req.write(data); }
-      req.end();
+      if (form) {
+        form.pipe(req);
+      } else {
+        if (data) { req.write(data); }
+        req.end();
+      }
     });
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kite-connector",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -348,8 +348,7 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "aws-sign2": {
       "version": "0.7.0",
@@ -626,7 +625,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
-      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -783,8 +781,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "diff": {
       "version": "3.5.0",
@@ -1392,7 +1389,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
       "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
-      "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "1.0.6",
@@ -2154,14 +2150,12 @@
     "mime-db": {
       "version": "1.33.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
-      "integrity": "sha1-o0kgUKXLm2NFBUHjnZeI0icng9s=",
-      "dev": true
+      "integrity": "sha1-o0kgUKXLm2NFBUHjnZeI0icng9s="
     },
     "mime-types": {
       "version": "2.1.18",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
       "integrity": "sha1-bzI/YKg9ERRvgx/xH9ZuL+VQO7g=",
-      "dev": true,
       "requires": {
         "mime-db": "~1.33.0"
       }

--- a/package.json
+++ b/package.json
@@ -41,5 +41,8 @@
     "mocha": "^5.2.0",
     "nyc": "^13.0.1",
     "sinon": "^2.3.5"
+  },
+  "dependencies": {
+    "form-data": "^2.3.2"
   }
 }

--- a/test/clients/node.test.js
+++ b/test/clients/node.test.js
@@ -151,5 +151,51 @@ describe('NodeClient', () => {
         });
       });
     });
+
+    describe('when the request has a multipart/form-data content type', () => {
+      beforeEach(() => {
+        requestStub = sinon.stub(http, 'request').callsFake(fakeRequestMethod(true));
+      });
+
+      afterEach(() => {
+        requestStub.restore();
+      });
+
+      it('builds the proper headers for Content-Type', () => {
+        promise = client.request({
+          path: '/foo',
+          headers: {
+            'Content-Type': 'multipart/form-data',
+          },
+        }, {
+          data1: 'foo',
+          data2: 'bar',
+        });
+        return promise.then((resp) => {
+          expect(/multipart\/form-data; boundary=/
+                .test(http.request.lastCall.args[0].headers['content-type'])
+              ).to.be.ok();
+          expect(resp.request.emit.called).to.be.ok();
+        });
+      });
+
+      it('builds the proper headers for content-type', () => {
+        promise = client.request({
+          path: '/foo',
+          headers: {
+            'content-type': 'multipart/form-data',
+          },
+        }, {
+          data1: 'foo',
+          data2: 'bar',
+        });
+        return promise.then((resp) => {
+          expect(/multipart\/form-data; boundary=/
+                .test(http.request.lastCall.args[0].headers['content-type'])
+              ).to.be.ok();
+          expect(resp.request.emit.called).to.be.ok();
+        });
+      });
+    });
   });
 });

--- a/test/helpers/http.js
+++ b/test/helpers/http.js
@@ -104,6 +104,8 @@ function fakeRequestMethod(resp) {
         }
       },
       write(data) {},
+      emit: sinon.spy(),
+      removeListener() {},
       setTimeout(timeout, callback) {
         if (resp == null) { callback({}); }
       },


### PR DESCRIPTION
Passing the content type header in the request options will let the 
client know that it'll have to build the form data accordingly