### PR TITLE
Laggy requests

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -46,10 +46,13 @@ module.exports = {
     console.log('KITE-CONNECT req', options)
     return this.client.request(options, data, timeout)
     .catch(() => {
-      return this.isKiteSupported()
-      .then(() => this.isKiteInstalled())
-      .then(() => this.isKiteRunning())
-      .then(() => {
+      let promise = Promise.resolve();
+      if (utils.shouldAddCatchProcessing(options.path)) {
+        promise = promise.then(() => this.isKiteSupported())
+              .then(() => this.isKiteInstalled())
+              .then(() => this.isKiteRunning());
+      }
+      return promise.then(() => {
         throw new KiteStateError('Kite could not be reached when attempting a request', {
           state: STATES.UNREACHABLE,
           request: options,

--- a/lib/index.js
+++ b/lib/index.js
@@ -157,7 +157,7 @@ module.exports = {
     return this.client.request({
       path: '/clientapi/ping',
       method: 'GET',
-    });
+    }, null, 200); // in tests, this took no longer than 15ms to respond
   },
 
   waitForKite(attempts, interval) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -159,7 +159,7 @@ module.exports = {
     return this.client.request({
       path: '/clientapi/ping',
       method: 'GET',
-    }, null, 200); // in tests, this took no longer than 15ms to respond
+    }, null, 100); // in tests, this took no longer than 15ms to respond
   },
 
   waitForKite(attempts, interval) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -71,6 +71,7 @@ module.exports = {
         : resp;
     })
     .catch(err => {
+      console.log('KITE-CONNECT failure', options)
       this.emitter.emit('did-fail-request', err);
       throw err;
     });

--- a/lib/index.js
+++ b/lib/index.js
@@ -43,7 +43,6 @@ module.exports = {
   },
 
   request(options, data, timeout) {
-    console.log('KITE-CONNECT req', options)
     return this.client.request(options, data, timeout)
     .catch(() => {
       let promise = Promise.resolve();
@@ -74,8 +73,6 @@ module.exports = {
         : resp;
     })
     .catch(err => {
-      console.log('KITE-CONNECT failure', options)
-      console.log('KITE CONNECT ERROR', err)
       this.emitter.emit('did-fail-request', err);
       throw err;
     });

--- a/lib/index.js
+++ b/lib/index.js
@@ -43,6 +43,7 @@ module.exports = {
   },
 
   request(options, data, timeout) {
+    console.log('KITE-CONNECT req', options)
     return this.client.request(options, data, timeout)
     .catch(() => {
       return this.isKiteSupported()

--- a/lib/index.js
+++ b/lib/index.js
@@ -72,6 +72,7 @@ module.exports = {
     })
     .catch(err => {
       console.log('KITE-CONNECT failure', options)
+      console.log('KITE CONNECT ERROR', err)
       this.emitter.emit('did-fail-request', err);
       throw err;
     });

--- a/lib/index.js
+++ b/lib/index.js
@@ -159,7 +159,7 @@ module.exports = {
     return this.client.request({
       path: '/clientapi/ping',
       method: 'GET',
-    }, null, 100); // in tests, this took no longer than 15ms to respond
+    }, null, 200); // in tests, this took no longer than 15ms to respond
   },
 
   waitForKite(attempts, interval) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -296,7 +296,9 @@ function parseJSON(json, fallback) {
 
 // evaluates whether a particular path should have extra processing
 // done on it in the case of a Promise rejection
+// NB: this should be taken out with a more robust refactor
 function shouldAddCatchProcessing(path) {
+  console.log('SHOULD CATCH PATH', path)
   return !path.includes('/clientapi/editor');
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -298,7 +298,7 @@ function parseJSON(json, fallback) {
 // done on it in the case of a Promise rejection
 // NB: this should be taken out with a more robust refactor
 function shouldAddCatchProcessing(path) {
-  return !path.includes('/clientapi/editor');
+  return !path.startsWith('/clientapi/editor');
 }
 
 module.exports = {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -298,7 +298,6 @@ function parseJSON(json, fallback) {
 // done on it in the case of a Promise rejection
 // NB: this should be taken out with a more robust refactor
 function shouldAddCatchProcessing(path) {
-  console.log('SHOULD CATCH PATH', path)
   return !path.includes('/clientapi/editor');
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -294,6 +294,12 @@ function parseJSON(json, fallback) {
   try { return JSON.parse(json) || fallback; } catch (e) { return fallback; }
 }
 
+// evaluates whether a particular path should have extra processing
+// done on it in the case of a Promise rejection
+function shouldAddCatchProcessing(path) {
+  return !path.includes('/clientapi/editor');
+}
+
 module.exports = {
   anyPromise,
   deepMerge,
@@ -309,5 +315,6 @@ module.exports = {
   promisifyStream,
   retryPromise,
   reversePromise,
+  shouldAddCatchProcessing,
   spawnPromise,
 };


### PR DESCRIPTION
Notes on testing: https://kite.quip.com/9LcOAtXD9csO

Connected PRs:
- https://github.com/kiteco/atom-plugin/pull/574
- https://github.com/kiteco/vscode-plugin/pull/212
- https://github.com/kiteco/kite-api-js/pull/13

This solves the general issue of having editor lag with VSCode and Atom plugins while typing with Kite Engine off, and is the result of a decent detailed investigation

This PR changes 2 things:
1. it adds a 100ms timeout for the request made by `isKiteReachable`. Though this didn't end up affecting performance, it fits semantically with what that method aims to represent. It could be plausibly be made shorter
2. it gates the `catch` processing of the `request` processing based on the url path that's attempted to be reached. For paths that contain `/clientapi/editor`, we no longer perform the heretofore typical `isKite<in-some-state>` calls that entailed expensive OS calls that we blocking the return of a response (and thus causing lagginess).

fixes #14 

In essence, in doing the failure processing for every `event`, `completions`, and `signatures` call, we were causing lag.

I attempted to be surgical here, and only restricted the processing for `event`, `completions`, and `signatures` calls, because they're the ones whose timings have by far the greatest effect on the user experience.

However, I think that this could stand more reworking, wrt where and when we ought to be performing these health checks. This seems like it would be something that would be more in the scope of a larger refactor of `kite-connector` and `kite-api`.