### PR TITLE
Treat all linux distros/versions as supported

### DIFF
--- a/lib/support/linux.js
+++ b/lib/support/linux.js
@@ -81,18 +81,7 @@ const LinuxSupport = {
   },
 
   isOSVersionSupported() {
-    // get version info from parsing output of process `lsb_release -r`
-    // which should be sufficient for Ubuntu distros
-    try {
-      const output = String(child_process.execSync('lsb_release -r'));
-      const version = parseFloat(output.substring(output.search(/\d/)).trim()); // find index of first digit
-      if (isNaN(version)) {
-        return false;
-      }
-      return version >= 18.04 && os.arch() === 'x64'; // we only support 18.04+ currently
-    } catch (e) {
-      return false;
-    }
+    return true;
   },
 
   isKiteSupported() {

--- a/test/support/linux.test.js
+++ b/test/support/linux.test.js
@@ -74,27 +74,6 @@ describe('LinuxAdapter', () => {
   });
 
   describe('.isOSVersionSupported()', () => {
-    describe('when the os version is not supported', () => {
-      beforeEach(() => {
-        commandsRestore = fakeCommands({
-          exec: {
-            'lsb_release -r': (ps) => {
-              ps.stdout('Release:	16.04');
-              return 0;
-            },
-          },
-        });
-      });
-
-      afterEach(() => {
-        commandsRestore.restore();
-      });
-
-      it('returns false', () => {
-        expect(LinuxAdapter.isOSVersionSupported()).not.to.be.ok();
-      });
-    });
-
     describe('when the os version is supported', () => {
       beforeEach(() => {
         commandsRestore = fakeCommands({
@@ -106,7 +85,7 @@ describe('LinuxAdapter', () => {
           },
         });
       });
-      
+
       afterEach(() => {
         commandsRestore.restore();
       });
@@ -163,9 +142,9 @@ describe('LinuxAdapter', () => {
             return LinuxAdapter.downloadKite(url, options)
             .then(() => {
               expect(https.request.calledWith(url)).to.be.ok();
-              expect(proc.spawn.calledWith('apt', 
+              expect(proc.spawn.calledWith('apt',
                 ['install', '-f', LinuxAdapter.KITE_DEB_PATH])).to.be.ok();
-              
+
               expect(fs.unlinkSync.calledWith(LinuxAdapter.KITE_DEB_PATH)).to.be.ok();
 
               expect(options.onInstallStart.called).to.be.ok();


### PR DESCRIPTION
@dbratz1177 This PR removes the Ubuntu 18.04+ version check, and simply treats linux as supported