### PR TITLE
should fix windows 10 issue

### DIFF
--- a/lib/support/windows.js
+++ b/lib/support/windows.js
@@ -92,13 +92,13 @@ const WindowsSupport = {
   },
 
   arch() {
-    if (this.cachedArch) { return this.cachedArch; }
-    try {
-      this.cachedArch = String(child_process.execSync(ARCH_BAT)).trim();
-      return this.cachedArch;
-    } catch (err) {
-      return '';
-    }
+    if (!this.cachedArch) { this.cachedArch = os.arch(); }
+    
+    // for backwards compatibility, we don't just return the direct result of the os call
+    if (this.cachedArch === 'x86') { return '32bit'; }
+    if (this.cachedArch === 'x64') { return '64bit'; }
+    
+    return this.cachedArch;
   },
 
   isOSSupported() {

--- a/lib/support/windows.js
+++ b/lib/support/windows.js
@@ -95,7 +95,7 @@ const WindowsSupport = {
     if (!this.cachedArch) { this.cachedArch = os.arch(); }
     
     // for backwards compatibility, we don't just return the direct result of the os call
-    if (this.cachedArch === 'x86') { return '32bit'; }
+    if (this.cachedArch === 'x32') { return '32bit'; }
     if (this.cachedArch === 'x64') { return '64bit'; }
     
     return this.cachedArch;


### PR DESCRIPTION
I wasn't able to reproduce this on my Windows 10 VM, but this addresses some things I was able to glean from Joachim's screenshot.

Based on Joachim's screenshot, it seems that this line of code was generating the notification: https://github.com/kiteco/atom-plugin/blob/master/lib/notifications-center.js#L171, with `arch` being an empty string. The empty string case happens when the execution of the BAT file errors.

so what we did:
1. Instead of relying on the BAT file to determine the architecture, we rely on Node's `os` library.

cc @its-dhung @jansorg 