### PR TITLE
Add flag to install supported plugins in "runKite()"

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -143,17 +143,17 @@ module.exports = {
     return this.isKiteInstalled()
     .then(() =>
       utils.reversePromise(this.isKiteRunning(),
-        new KiteStateError('Kite is already runnning', {
+        new KiteStateError('Kite is already running', {
           state: STATES.RUNNING,
         })));
   },
 
-  runKite() {
-    return this.adapter.runKite();
+  runKite(installSupportedPlugins) {
+    return this.adapter.runKite(installSupportedPlugins);
   },
 
-  runKiteAndWait(attempts, interval) {
-    return this.runKite().then(() => this.waitForKite(attempts, interval));
+  runKiteAndWait(attempts, interval, installPlugins) {
+    return this.runKite(installPlugins).then(() => this.waitForKite(attempts, interval));
   },
 
   isKiteReachable() {
@@ -179,7 +179,7 @@ module.exports = {
     return this.isKiteEnterpriseInstalled()
     .then(() =>
       utils.reversePromise(this.isKiteEnterpriseRunning(),
-        new KiteStateError('Kite Enterprise is already runnning', {
+        new KiteStateError('Kite Enterprise is already running', {
           state: STATES.RUNNING,
         })));
   },

--- a/lib/support/linux.js
+++ b/lib/support/linux.js
@@ -147,13 +147,6 @@ const LinuxSupport = {
   },
 
   streamKiteDownload(scriptPath, progress) {
-    // fixme remove after testing
-    let path = '/home/jansorg/go/src/github.com/kiteco/kiteco/linux/docker/kite-installer.sh';
-    if (fs.existsSync(path)) {
-      //scriptPath = path
-      fs.copyFileSync(path, scriptPath);
-    }
-
     // we can't use util.spawnPromise here because we have to stream stdout in chunks to handle the progress
     return new Promise((resolve, reject) => {
       try {

--- a/lib/support/linux.js
+++ b/lib/support/linux.js
@@ -67,10 +67,23 @@ const LinuxSupport = {
 
   isAdmin() {
     try {
-      const userInfo = os.userInfo();
-      return userInfo.uid === 0 || userInfo.username === "root";
+      const user = utils.whoami();
+      const adminUsers = String(child_process.execSync('getent group root adm admin sudo'))
+      .split('\n')
+      .map(line => line.substring(line.lastIndexOf(':') + 1))
+      .reduce((acc, val) => {
+        val.split(',').forEach(token => acc.push(token.trim()));
+        return acc;
+      }, []);
+      return adminUsers.includes(user);
     } catch (e) {
-      return false;
+      // fallback to os.serInfo()
+      try {
+        const userInfo = os.userInfo();
+        return userInfo.uid === 0 || userInfo.username === "root";
+      } catch (e) {
+        return false;
+      }
     }
   },
 
@@ -138,15 +151,15 @@ const LinuxSupport = {
     return new Promise((resolve, reject) => {
       try {
         const child = child_process.spawn(scriptPath, ["--download"], {shell: true})
-        if (progress) {
-          child.on('close', function (code) {
-            if (code === 0) {
-              resolve(child)
-            } else {
-              reject(code)
-            }
-          })
+        child.on('close', function (code) {
+          if (code === 0) {
+            resolve(child)
+          } else {
+            reject(code)
+          }
+        })
 
+        if (progress) {
           let pattern = /^Download: (\d+)\/(\d+)$/;
           let last = -1
           child.stdout.on('data', chunk => {
@@ -215,7 +228,6 @@ const LinuxSupport = {
         child_process.spawn(this.installPath,
           ['--plugin-launch', '--channel=autocomplete-python'],
           {detached: true, stdio: 'ignore', env})
-        .unref();
       } catch (e) {
         throw new KiteProcessError('kited_error',
         {

--- a/lib/support/linux.js
+++ b/lib/support/linux.js
@@ -106,13 +106,13 @@ const LinuxSupport = {
 
   isKiteInstalled() {
     return new Promise((resolve, reject) => {
-      fs.exists(this.installPath, exists => {
-        if (exists) {
-          resolve();
-        } else {
+      fs.access(this.installPath, fs.constants.R_OK, (err) => {
+        if (err) {
           reject(new KiteStateError('', {
             state: STATES.UNINSTALLED,
           }));
+        } else {
+          resolve();
         }
       });
     });
@@ -218,7 +218,7 @@ const LinuxSupport = {
     });
   },
 
-  runKite() {
+  runKite(installSupportedPlugins) {
     return this.isKiteRunning()
     .catch(() => {
       const env = Object.assign({}, process.env);

--- a/lib/support/linux.js
+++ b/lib/support/linux.js
@@ -32,10 +32,7 @@ const LinuxSupport = {
 
   get installPath() {
     if (!this.memKitedInstallPath) {
-      if (fs.existsSync(this.KITED_PATH)) {
-        this.memKitedInstallPath = this.KITED_PATH;
-      }
-      //fixme what if path didn't exist?
+      this.memKitedInstallPath = this.KITED_PATH;
     }
     return this.memKitedInstallPath;
   },
@@ -123,13 +120,13 @@ const LinuxSupport = {
   },
 
   downloadKiteInstallerScript(url) {
-    console.log("downloading script from " + url)
     const req = https.request(url);
     req.end();
 
     return utils.followRedirections(req)
     .then(resp => {
       return utils.promisifyStream(resp.pipe(fs.createWriteStream(this.downloadPath)))
+      .then(() => fs.chmodSync(this.downloadPath, 0o700))
       .then(() => new Promise((resolve, reject) => {
         setTimeout(resolve, 100);
       }));
@@ -137,59 +134,35 @@ const LinuxSupport = {
   },
 
   streamKiteDownload(scriptPath, progress) {
+    // we can't use util.spawnPromise here because we have to stream stdout in chunks to handle the progress
     return new Promise((resolve, reject) => {
       try {
-        // fixme remove after testing
-        let path = "/home/jansorg/go/src/github.com/kiteco/kiteco/linux/docker/kite-installer.sh";
-        if (fs.existsSync(path)) {
-          scriptPath = path
-          fs.copyFileSync(path, this.KITE_INSTALLER_PATH)
-        }
-
-        console.log(`"${scriptPath}" --download`)
-
         const child = child_process.spawn(scriptPath, ["--download"], {shell: true})
         if (progress) {
+          child.on('close', function (code) {
+            if (code === 0) {
+              resolve(child)
+            } else {
+              reject(code)
+            }
+          })
+
+          let pattern = /^Download: (\d+)\/(\d+)$/;
           let last = -1
           child.stdout.on('data', chunk => {
             // chunk is a buffer when used with spawn
             let line = chunk.toString('utf8')
-            let pattern = /^Download: (\d+)\/(\d+)$/;
             let match = pattern.exec(line)
             if (match) {
               let received = parseInt(match[1]);
               let total = parseInt(match[2]);
-              if (received >= 0 && total > 0 && total >= received) {
-                if (received > last) {
-                  last = received
-                  if (received === total) {
-                    progress(total, total, 1.0)
-                  } else {
-                    progress(received, total, received / total)
-                  }
-                }
+              if (received >= 0 && total >= received && received > last) {
+                last = received
+                progress(received, total, received / total)
               }
             }
           })
         }
-
-        child.on('close', function (code) {
-          console.log('child process exited with code ' + code);
-          if (code === 0) {
-            resolve(child)
-          } else {
-            reject(code)
-          }
-        });
-        // child.addListener("error", reject)
-        // child.addListener("exit", (code) => {
-        //   console.error("exit " + code)
-        //   if (code === 0) {
-        //     resolve(child)
-        //   } else {
-        //     reject(code)
-        //   }
-        // })
       } catch (e) {
         console.error(e)
         reject(e)
@@ -201,23 +174,9 @@ const LinuxSupport = {
     opts = opts || {};
 
     utils.guardCall(opts.onInstallStart);
-    return utils.spawnPromise("bash", [`"${this.KITE_INSTALLER_PATH}"`, "--install"],
-    'kite-installer install error', `unable to install kite from ${this.KITE_INSTALLER_PATH}`)
-    .catch((err) => {
-      // if permissions error, send message directing how complete with
-      // given installer path
-      // fixme permission errors
-      // if (err.code === 'EPERM' || err.errno === 'EPERM') {
-      //   throw new KiteProcessError('kite-installer.sh EPERM', {
-      //     message: `Installing ${this.KITE_INSTALLER_PATH} failed due to lacking root permissions.
-      //     In your command line, try running \`sudo apt install -f ${this.KITE_INSTALLER_PATH}\` to finish installing Kite`,
-      //     cmd: `bash ${this.KITE_INSTALLER_PATH} install`,
-      //   });
-      // } else {
-      // throw err;
-      // }
-      console.error("error installing kite: " + err)
-    })
+    return utils.spawnPromise(this.KITE_INSTALLER_PATH,
+      ["--install"], {shell: true},
+      'kite-installer install error', `unable to install kite with ${this.KITE_INSTALLER_PATH}`)
     .then(() => this.resetInstallPath()) // force recalculation of mem'd path on successful install
     .then(() => utils.guardCall(opts.onMount))
     .then(() => fs.unlinkSync(this.KITE_INSTALLER_PATH))
@@ -253,10 +212,10 @@ const LinuxSupport = {
         if (!fs.existsSync(this.installPath)) {
           throw new Error('kited is not installed');
         }
-        child_process.spawn(
-        this.installPath,
-        ['--plugin-launch', '--channel=autocomplete-python'],
-        {detached: true, env});
+        child_process.spawn(this.installPath,
+          ['--plugin-launch', '--channel=autocomplete-python'],
+          {detached: true, stdio: 'ignore', env})
+        .unref();
       } catch (e) {
         throw new KiteProcessError('kited_error',
         {

--- a/lib/support/linux.js
+++ b/lib/support/linux.js
@@ -15,11 +15,10 @@ const {STATES} = require('../constants');
 const LinuxSupport = {
   RELEASE_URL: 'https://linux.kite.com/dls/linux/current',
   SESSION_FILE_PATH: path.join(os.homedir(), '.kite', 'session.json'),
-  KITE_DEB_PATH: '/tmp/kite-installer.deb',
+  KITE_INSTALLER_PATH: '/tmp/kite-installer.sh',
   KITED_PATH: path.join(os.homedir(), '.local', 'share', 'kite', 'kited'),
-  FALLBACK_KITED_PATH: '/opt/kite/kited',
   KITED_PROCESS: /kited/,
-  KITE_CURRENT_LINK: '/opt/kite/current',
+  KITE_CURRENT_LINK: path.join(os.homedir(), '.local', 'share', 'kite', 'current'),
 
   memKitedInstallPath: null,
 
@@ -28,16 +27,15 @@ const LinuxSupport = {
   },
 
   get downloadPath() {
-    return this.KITE_DEB_PATH;
+    return this.KITE_INSTALLER_PATH;
   },
 
   get installPath() {
     if (!this.memKitedInstallPath) {
       if (fs.existsSync(this.KITED_PATH)) {
         this.memKitedInstallPath = this.KITED_PATH;
-      } else {
-        this.memKitedInstallPath = this.FALLBACK_KITED_PATH;
       }
+      //fixme what if path didn't exist?
     }
     return this.memKitedInstallPath;
   },
@@ -72,15 +70,8 @@ const LinuxSupport = {
 
   isAdmin() {
     try {
-      const user = utils.whoami();
-      const adminUsers = String(child_process.execSync('getent group root adm admin sudo'))
-      .split('\n')
-      .map(line => line.substring(line.lastIndexOf(':') + 1))
-      .reduce((acc, val) => {
-        val.split(',').forEach(token => acc.push(token.trim()));
-        return acc;
-      }, []);
-      return adminUsers.includes(user);
+      const userInfo = os.userInfo();
+      return userInfo.uid === 0 || userInfo.username === "root";
     } catch (e) {
       return false;
     }
@@ -95,7 +86,8 @@ const LinuxSupport = {
   },
 
   isOSVersionSupported() {
-    return true;
+    let arch = os.arch();
+    return arch === "x64";
   },
 
   isKiteSupported() {
@@ -116,80 +108,129 @@ const LinuxSupport = {
     });
   },
 
-  // TODO(dane): move outside of specific adapter with same methods in osx and windows
+  // downloads the latest version of kite-installer.sh
+  // and uses it to retrieve the current binary installer and installation data
   downloadKiteRelease(opts) {
     return this.downloadKite(this.releaseURL, opts || {});
   },
 
   downloadKite(url, opts) {
-    // TODO(dane): move outside of specific adapter with same methods in osx and windows
     opts = opts || {};
-    return this.streamKiteDownload(url, opts.onDownloadProgress)
+    return this.downloadKiteInstallerScript(url)
+    .then(() => this.streamKiteDownload(this.downloadPath, opts.onDownloadProgress))
     .then(() => utils.guardCall(opts.onDownload))
     .then(() => opts.install && this.installKite(opts));
   },
 
-  // TODO(dane): move outside of specific adapter with same methods in osx and windows
-  streamKiteDownload(url, progress) {
+  downloadKiteInstallerScript(url) {
+    console.log("downloading script from " + url)
     const req = https.request(url);
     req.end();
 
     return utils.followRedirections(req)
     .then(resp => {
-      if (progress) {
-        const total = parseInt(resp.headers['content-length'], 10);
-        let length = 0;
-
-        resp.on('data', chunk => {
-          length += chunk.length;
-          progress(length, total, length / total);
-        });
-      }
-      return utils.promisifyStream(
-        resp.pipe(fs.createWriteStream(this.downloadPath))
-      )
+      return utils.promisifyStream(resp.pipe(fs.createWriteStream(this.downloadPath)))
       .then(() => new Promise((resolve, reject) => {
         setTimeout(resolve, 100);
       }));
     });
   },
 
+  streamKiteDownload(scriptPath, progress) {
+    return new Promise((resolve, reject) => {
+      try {
+        // fixme remove after testing
+        let path = "/home/jansorg/go/src/github.com/kiteco/kiteco/linux/docker/kite-installer.sh";
+        if (fs.existsSync(path)) {
+          scriptPath = path
+          fs.copyFileSync(path, this.KITE_INSTALLER_PATH)
+        }
+
+        console.log(`"${scriptPath}" --download`)
+
+        const child = child_process.spawn(scriptPath, ["--download"], {shell: true})
+        if (progress) {
+          let last = -1
+          child.stdout.on('data', chunk => {
+            // chunk is a buffer when used with spawn
+            let line = chunk.toString('utf8')
+            let pattern = /^Download: (\d+)\/(\d+)$/;
+            let match = pattern.exec(line)
+            if (match) {
+              let received = parseInt(match[1]);
+              let total = parseInt(match[2]);
+              if (received >= 0 && total > 0 && total >= received) {
+                if (received > last) {
+                  last = received
+                  if (received === total) {
+                    progress(total, total, 1.0)
+                  } else {
+                    progress(received, total, received / total)
+                  }
+                }
+              }
+            }
+          })
+        }
+
+        child.on('close', function (code) {
+          console.log('child process exited with code ' + code);
+          if (code === 0) {
+            resolve(child)
+          } else {
+            reject(code)
+          }
+        });
+        // child.addListener("error", reject)
+        // child.addListener("exit", (code) => {
+        //   console.error("exit " + code)
+        //   if (code === 0) {
+        //     resolve(child)
+        //   } else {
+        //     reject(code)
+        //   }
+        // })
+      } catch (e) {
+        console.error(e)
+        reject(e)
+      }
+    })
+  },
+
   installKite(opts) {
     opts = opts || {};
 
     utils.guardCall(opts.onInstallStart);
-    return utils.spawnPromise(
-      'apt',
-      ['install', '-f', this.KITE_DEB_PATH],
-      { gid: 27 }, //sudo group
-      'apt install error',
-      'unable to install kite from kite-installer.deb')
+    return utils.spawnPromise("bash", [`"${this.KITE_INSTALLER_PATH}"`, "--install"],
+    'kite-installer install error', `unable to install kite from ${this.KITE_INSTALLER_PATH}`)
     .catch((err) => {
       // if permissions error, send message directing how complete with
-      // given deb path
-      if (err.code === 'EPERM' || err.errno === 'EPERM') {
-        throw new KiteProcessError('kite-installer.deb EPERM', {
-          message: `Installing ${this.KITE_DEB_PATH} failed due to lacking root permissions.
-          In your command line, try running \`sudo apt install -f ${this.KITE_DEB_PATH}\` to finish installing Kite`,
-          cmd: `apt install -f ${this.KITE_DEB_PATH}`,
-        });
-      } else {
-        throw err;
-      }
+      // given installer path
+      // fixme permission errors
+      // if (err.code === 'EPERM' || err.errno === 'EPERM') {
+      //   throw new KiteProcessError('kite-installer.sh EPERM', {
+      //     message: `Installing ${this.KITE_INSTALLER_PATH} failed due to lacking root permissions.
+      //     In your command line, try running \`sudo apt install -f ${this.KITE_INSTALLER_PATH}\` to finish installing Kite`,
+      //     cmd: `bash ${this.KITE_INSTALLER_PATH} install`,
+      //   });
+      // } else {
+      // throw err;
+      // }
+      console.error("error installing kite: " + err)
     })
     .then(() => this.resetInstallPath()) // force recalculation of mem'd path on successful install
     .then(() => utils.guardCall(opts.onMount))
-    .then(() => fs.unlinkSync(this.KITE_DEB_PATH))
+    .then(() => fs.unlinkSync(this.KITE_INSTALLER_PATH))
     .then(() => utils.guardCall(opts.onRemove));
   },
 
   isKiteRunning() {
     return utils.spawnPromise(
-      '/bin/ps',
-      ['-axo', 'pid,command'],
-      {encoding: 'utf-8'},
-      'ps_error',
-      'unable to run the ps command and verify that Kite is running')
+    '/bin/ps',
+    ['-axo', 'pid,command'],
+    {encoding: 'utf-8'},
+    'ps_error',
+    'unable to run the ps command and verify that Kite is running')
     .then(stdout => {
       const procs = stdout.split('\n');
 
@@ -213,17 +254,17 @@ const LinuxSupport = {
           throw new Error('kited is not installed');
         }
         child_process.spawn(
-          this.installPath,
-          ['--plugin-launch', '--channel=autocomplete-python'],
-          { detached: true, env });
+        this.installPath,
+        ['--plugin-launch', '--channel=autocomplete-python'],
+        {detached: true, env});
       } catch (e) {
         throw new KiteProcessError('kited_error',
-          {
-            message: (e.message && e.message === 'kited is not installed') || 'unable to run kited binary',
-            callStack: e.stack,
-            cmd: this.installPath,
-            options: { detached: true, env },
-          });
+        {
+          message: (e.message && e.message === 'kited is not installed') || 'unable to run kited binary',
+          callStack: e.stack,
+          cmd: this.installPath,
+          options: {detached: true, env},
+        });
       }
     });
   },
@@ -249,9 +290,9 @@ const LinuxSupport = {
 
   notSupported() {
     return Promise.reject(
-      new KiteStateError('Your platform is currently not supported', {
-        state: STATES.UNSUPPORTED,
-      }));
+    new KiteStateError('Your platform is currently not supported', {
+      state: STATES.UNSUPPORTED,
+    }));
   },
 };
 

--- a/lib/support/linux.js
+++ b/lib/support/linux.js
@@ -77,7 +77,7 @@ const LinuxSupport = {
       }, []);
       return adminUsers.includes(user);
     } catch (e) {
-      // fallback to os.serInfo()
+      // fallback to os.userInfo()
       try {
         const userInfo = os.userInfo();
         return userInfo.uid === 0 || userInfo.username === 'root';
@@ -147,6 +147,13 @@ const LinuxSupport = {
   },
 
   streamKiteDownload(scriptPath, progress) {
+    // fixme remove after testing
+    let path = '/home/jansorg/go/src/github.com/kiteco/kiteco/linux/docker/kite-installer.sh';
+    if (fs.existsSync(path)) {
+      //scriptPath = path
+      fs.copyFileSync(path, scriptPath);
+    }
+
     // we can't use util.spawnPromise here because we have to stream stdout in chunks to handle the progress
     return new Promise((resolve, reject) => {
       try {

--- a/lib/support/linux.js
+++ b/lib/support/linux.js
@@ -80,8 +80,8 @@ const LinuxSupport = {
       // fallback to os.serInfo()
       try {
         const userInfo = os.userInfo();
-        return userInfo.uid === 0 || userInfo.username === "root";
-      } catch (e) {
+        return userInfo.uid === 0 || userInfo.username === 'root';
+      } catch (ignored) {
         return false;
       }
     }
@@ -97,7 +97,7 @@ const LinuxSupport = {
 
   isOSVersionSupported() {
     let arch = os.arch();
-    return arch === "x64";
+    return arch === 'x64';
   },
 
   isKiteSupported() {
@@ -150,41 +150,41 @@ const LinuxSupport = {
     // we can't use util.spawnPromise here because we have to stream stdout in chunks to handle the progress
     return new Promise((resolve, reject) => {
       try {
-        const child = child_process.spawn(scriptPath, ["--download"], {shell: true})
-        child.on('close', function (code) {
+        const child = child_process.spawn(scriptPath, ['--download'], {shell: true});
+        child.on('close', function(code) {
           if (code === 0) {
-            resolve(child)
+            resolve(child);
           } else {
-            reject(code)
+            reject(code);
           }
-        })
+        });
 
         if (progress) {
-          let last = -1
+          let last = -1;
           child.stdout.on('data', chunk => {
             // chunk is a buffer when used with spawn
-            let line = chunk.toString('utf8')
-            let pattern = /Download: (\d+)\/(\d+)/g
-            let lastMatch, match
-            while ((match = pattern.exec(line)) !== null){
-              lastMatch = match
+            let line = chunk.toString('utf8');
+            let pattern = /Download: (\d+)\/(\d+)/g;
+            let lastMatch, match;
+            while ((match = pattern.exec(line)) !== null) {
+              lastMatch = match;
             }
 
             if (lastMatch) {
-              let received = parseInt(lastMatch[1]);
-              let total = parseInt(lastMatch[2]);
+              let received = parseInt(lastMatch[1], 10);
+              let total = parseInt(lastMatch[2], 10);
               if (received >= 0 && total >= received && received > last) {
-                last = received
-                progress(received, total, received / total)
+                last = received;
+                progress(received, total, received / total);
               }
             }
-          })
+          });
         }
       } catch (e) {
-        console.error(e)
-        reject(e)
+        console.error(e);
+        reject(e);
       }
-    })
+    });
   },
 
   installKite(opts) {
@@ -192,8 +192,8 @@ const LinuxSupport = {
 
     utils.guardCall(opts.onInstallStart);
     return utils.spawnPromise(this.KITE_INSTALLER_PATH,
-      ["--install"], {shell: true},
-      'kite-installer install error', `unable to install kite with ${this.KITE_INSTALLER_PATH}`)
+    ['--install'], {shell: true},
+    'kite-installer install error', `unable to install kite with ${this.KITE_INSTALLER_PATH}`)
     .then(() => this.resetInstallPath()) // force recalculation of mem'd path on successful install
     .then(() => utils.guardCall(opts.onMount))
     .then(() => fs.unlinkSync(this.KITE_INSTALLER_PATH))
@@ -230,16 +230,16 @@ const LinuxSupport = {
           throw new Error('kited is not installed');
         }
         child_process.spawn(this.installPath,
-          ['--plugin-launch', '--channel=autocomplete-python'],
-          {detached: true, stdio: 'ignore', env})
+        ['--plugin-launch', '--channel=autocomplete-python'],
+        {detached: true, stdio: 'ignore', env});
       } catch (e) {
         throw new KiteProcessError('kited_error',
-        {
-          message: (e.message && e.message === 'kited is not installed') || 'unable to run kited binary',
-          callStack: e.stack,
-          cmd: this.installPath,
-          options: {detached: true, env},
-        });
+          {
+            message: (e.message && e.message === 'kited is not installed') || 'unable to run kited binary',
+            callStack: e.stack,
+            cmd: this.installPath,
+            options: {detached: true, env},
+          });
       }
     });
   },

--- a/lib/support/linux.js
+++ b/lib/support/linux.js
@@ -160,15 +160,19 @@ const LinuxSupport = {
         })
 
         if (progress) {
-          let pattern = /^Download: (\d+)\/(\d+)$/;
           let last = -1
           child.stdout.on('data', chunk => {
             // chunk is a buffer when used with spawn
             let line = chunk.toString('utf8')
-            let match = pattern.exec(line)
-            if (match) {
-              let received = parseInt(match[1]);
-              let total = parseInt(match[2]);
+            let pattern = /Download: (\d+)\/(\d+)/g
+            let lastMatch, match
+            while ((match = pattern.exec(line)) !== null){
+              lastMatch = match
+            }
+
+            if (lastMatch) {
+              let received = parseInt(lastMatch[1]);
+              let total = parseInt(lastMatch[2]);
               if (received >= 0 && total >= received && received > last) {
                 last = received
                 progress(received, total, received / total)

--- a/lib/support/linux.js
+++ b/lib/support/linux.js
@@ -15,7 +15,7 @@ const {STATES} = require('../constants');
 const LinuxSupport = {
   RELEASE_URL: 'https://linux.kite.com/dls/linux/current',
   SESSION_FILE_PATH: path.join(os.homedir(), '.kite', 'session.json'),
-  KITE_INSTALLER_PATH: '/tmp/kite-installer.sh',
+  KITE_INSTALLER_PATH: path.join(os.tmpdir(), 'kite-installer.sh'),
   KITED_PATH: path.join(os.homedir(), '.local', 'share', 'kite', 'kited'),
   KITED_PROCESS: /kited/,
   KITE_CURRENT_LINK: path.join(os.homedir(), '.local', 'share', 'kite', 'current'),

--- a/lib/support/osx.js
+++ b/lib/support/osx.js
@@ -221,7 +221,7 @@ const OSXSupport = {
     });
   },
 
-  runKite() {
+  runKite(installSupportedPlugins) {
     const env = Object.assign({}, process.env);
     delete env['ELECTRON_RUN_AS_NODE'];
 

--- a/lib/support/windows.js
+++ b/lib/support/windows.js
@@ -222,7 +222,7 @@ const WindowsSupport = {
     });
   },
 
-  runKite() {
+  runKite(installSupportedPlugins) {
     return this.isKiteRunning()
     .catch(() => {
       var env = Object.create(process.env);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -197,7 +197,6 @@ function spawnPromise(cmd, cmdArgs, cmdOptions, rejectionType, rejectionMessage)
   }
 
   return new Promise((resolve, reject) => {
-    console.log("Running: ", ...args)
     const proc = child_process.spawn(...args);
     let stdout = '';
     let stderr = '';

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -197,6 +197,7 @@ function spawnPromise(cmd, cmdArgs, cmdOptions, rejectionType, rejectionMessage)
   }
 
   return new Promise((resolve, reject) => {
+    console.log("Running: ", ...args)
     const proc = child_process.spawn(...args);
     let stdout = '';
     let stderr = '';

--- a/test/support/linux.test.js
+++ b/test/support/linux.test.js
@@ -14,7 +14,7 @@ const {fakeCommands} = require('../helpers/child_process');
 const {
   withKiteInstalled, withKiteRunning, withKiteNotRunning,
 } = require('../helpers/system');
-const {kiteDownloadRoutes} = require('../helpers/kite');
+const { kiteDownloadRoutes } = require('../helpers/kite');
 
 const PLATFORM = 'linux';
 

--- a/test/support/linux.test.js
+++ b/test/support/linux.test.js
@@ -3,6 +3,8 @@
 const proc = require('child_process');
 const fs = require('fs');
 const https = require('https');
+const os = require('os');
+const path = require('path');
 const sinon = require('sinon');
 const expect = require('expect.js');
 
@@ -120,7 +122,7 @@ describe('LinuxAdapter', () => {
           unlinkSpy = sinon.stub(fs, 'unlinkSync');
 
           commandsRestore = fakeCommands({
-            '/tmp/kite-installer.sh': () => 0,
+            [path.join(os.tmpdir(), 'kite-installer.sh')]: () => 0,
           });
         });
 
@@ -142,7 +144,7 @@ describe('LinuxAdapter', () => {
             return LinuxAdapter.downloadKite(url, options)
             .then(() => {
               expect(https.request.calledWith(url)).to.be.ok();
-              expect(proc.spawn.calledWith('/tmp/kite-installer.sh', ['--download'])).to.be.ok();
+              expect(proc.spawn.calledWith(path.join(os.tmpdir(), 'kite-installer.sh'), ['--download'])).to.be.ok();
               expect(fs.unlinkSync.calledWith(LinuxAdapter.KITE_INSTALLER_PATH)).to.be.ok();
 
               expect(options.onInstallStart.called).to.be.ok();
@@ -161,7 +163,7 @@ describe('LinuxAdapter', () => {
       beforeEach(() => {
         unlinkSpy = sinon.stub(fs, 'unlinkSync');
         commandsRestore = fakeCommands({
-          '/tmp/kite-installer.sh': () => 0,
+          [path.join(os.tmpdir(), 'kite-installer.sh')]: () => 0,
         });
       });
 
@@ -178,7 +180,7 @@ describe('LinuxAdapter', () => {
         };
         return waitsForPromise(() => LinuxAdapter.installKite(options))
         .then(() => {
-          expect(proc.spawn.calledWith('/tmp/kite-installer.sh', ['--install'])).to.be.ok();
+          expect(proc.spawn.calledWith(path.join(os.tmpdir(), 'kite-installer.sh'), ['--install'])).to.be.ok();
           expect(fs.unlinkSync.calledWith(LinuxAdapter.KITE_INSTALLER_PATH)).to.be.ok();
 
           expect(options.onInstallStart.called).to.be.ok();

--- a/test/support/linux.test.js
+++ b/test/support/linux.test.js
@@ -143,9 +143,9 @@ describe('LinuxAdapter', () => {
             .then(() => {
               expect(https.request.calledWith(url)).to.be.ok();
               expect(proc.spawn.calledWith('apt',
-                ['install', '-f', LinuxAdapter.KITE_DEB_PATH])).to.be.ok();
+                ['install', '-f', LinuxAdapter.KITE_INSTALLER_PATH])).to.be.ok();
 
-              expect(fs.unlinkSync.calledWith(LinuxAdapter.KITE_DEB_PATH)).to.be.ok();
+              expect(fs.unlinkSync.calledWith(LinuxAdapter.KITE_INSTALLER_PATH)).to.be.ok();
 
               expect(options.onInstallStart.called).to.be.ok();
               expect(options.onMount.called).to.be.ok();
@@ -181,9 +181,9 @@ describe('LinuxAdapter', () => {
         return waitsForPromise(() => LinuxAdapter.installKite(options))
         .then(() => {
           expect(proc.spawn.calledWith('apt', [
-            'install', '-f', LinuxAdapter.KITE_DEB_PATH,
+            'install', '-f', LinuxAdapter.KITE_INSTALLER_PATH,
           ])).to.be.ok();
-          expect(fs.unlinkSync.calledWith(LinuxAdapter.KITE_DEB_PATH)).to.be.ok();
+          expect(fs.unlinkSync.calledWith(LinuxAdapter.KITE_INSTALLER_PATH)).to.be.ok();
 
           expect(options.onInstallStart.called).to.be.ok();
           expect(options.onMount.called).to.be.ok();

--- a/test/support/linux.test.js
+++ b/test/support/linux.test.js
@@ -14,7 +14,7 @@ const {fakeCommands} = require('../helpers/child_process');
 const {
   withKiteInstalled, withKiteRunning, withKiteNotRunning,
 } = require('../helpers/system');
-const { kiteDownloadRoutes } = require('../helpers/kite');
+const {kiteDownloadRoutes} = require('../helpers/kite');
 
 const PLATFORM = 'linux';
 
@@ -120,7 +120,7 @@ describe('LinuxAdapter', () => {
           unlinkSpy = sinon.stub(fs, 'unlinkSync');
 
           commandsRestore = fakeCommands({
-            'apt': () => 0,
+            '/tmp/kite-installer.sh': () => 0,
           });
         });
 
@@ -142,9 +142,7 @@ describe('LinuxAdapter', () => {
             return LinuxAdapter.downloadKite(url, options)
             .then(() => {
               expect(https.request.calledWith(url)).to.be.ok();
-              expect(proc.spawn.calledWith('apt',
-                ['install', '-f', LinuxAdapter.KITE_INSTALLER_PATH])).to.be.ok();
-
+              expect(proc.spawn.calledWith('/tmp/kite-installer.sh', ['--download'])).to.be.ok();
               expect(fs.unlinkSync.calledWith(LinuxAdapter.KITE_INSTALLER_PATH)).to.be.ok();
 
               expect(options.onInstallStart.called).to.be.ok();
@@ -163,7 +161,7 @@ describe('LinuxAdapter', () => {
       beforeEach(() => {
         unlinkSpy = sinon.stub(fs, 'unlinkSync');
         commandsRestore = fakeCommands({
-          'apt': () => 0,
+          '/tmp/kite-installer.sh': () => 0,
         });
       });
 
@@ -180,9 +178,7 @@ describe('LinuxAdapter', () => {
         };
         return waitsForPromise(() => LinuxAdapter.installKite(options))
         .then(() => {
-          expect(proc.spawn.calledWith('apt', [
-            'install', '-f', LinuxAdapter.KITE_INSTALLER_PATH,
-          ])).to.be.ok();
+          expect(proc.spawn.calledWith('/tmp/kite-installer.sh', ['--install'])).to.be.ok();
           expect(fs.unlinkSync.calledWith(LinuxAdapter.KITE_INSTALLER_PATH)).to.be.ok();
 
           expect(options.onInstallStart.called).to.be.ok();
@@ -314,10 +310,10 @@ describe('LinuxAdapter', () => {
 
       it('returns a resolved promise', () => {
         return waitsForPromise(() => LinuxAdapter.runKite())
-          .then(() => {
-            expect(proc.spawn.lastCall.args[0])
-            .to.eql(LinuxAdapter.KITED_PATH);
-          });
+        .then(() => {
+          expect(proc.spawn.lastCall.args[0])
+          .to.eql(LinuxAdapter.KITED_PATH);
+        });
       });
     });
   });


### PR DESCRIPTION
Based on https://github.com/kiteco/kite-connect-js/pull/27, which must be merged first.

This PR updates the kite-connector API with a new flag for `runKite()` to make kited install all supported editor plugins at startup.

Part of https://github.com/kiteco/kiteco/issues/8451