### PR TITLE
Use the new --plugin-launch-with-copilot flags when launching Kited.

### DIFF
--- a/lib/support/linux.js
+++ b/lib/support/linux.js
@@ -230,7 +230,7 @@ const LinuxSupport = {
           throw new Error('kited is not installed');
         }
         child_process.spawn(this.installPath,
-        ['--plugin-launch', '--channel=autocomplete-python'],
+        ['--plugin-launch-with-copilot', '--channel=autocomplete-python'],
         {detached: true, stdio: 'ignore', env});
       } catch (e) {
         throw new KiteProcessError('kited_error',

--- a/lib/support/osx.js
+++ b/lib/support/osx.js
@@ -234,7 +234,7 @@ const OSXSupport = {
     .then(() =>
     utils.spawnPromise(
       'open',
-      ['-a', this.installPath, '--args', '--plugin-launch', '--channel=autocomplete-python'],
+      ['-a', this.installPath, '--args', '--plugin-launch-with-copilot', '--channel=autocomplete-python'],
       { env: env },
       'open_error',
       'Unable to run the open command to start Kite'

--- a/lib/support/windows.js
+++ b/lib/support/windows.js
@@ -198,7 +198,7 @@ const WindowsSupport = {
 
     utils.guardCall(opts.onInstallStart);
     return utils.execPromise(
-      `"${this.KITE_INSTALLER_PATH}"` + ' --skip-onboarding --plugin-launch --channel=autocomplete-python',
+      `"${this.KITE_INSTALLER_PATH}"` + ' --skip-onboarding --plugin-launch-with-copilot --channel=autocomplete-python',
       {env: env},
       'kite_install_error',
       'Unable to run Kite installer')
@@ -232,7 +232,7 @@ const WindowsSupport = {
       try {
         child_process.spawn(
           this.KITE_EXE_PATH,
-          ['--plugin-launch', '--channel=autocomplete-python'],
+          ['--plugin-launch-with-copilot', '--channel=autocomplete-python'],
           {detached: true, env: env});
       } catch (err) {
         throw new KiteProcessError('kite_exe_error',

--- a/test/support/osx.test.js
+++ b/test/support/osx.test.js
@@ -339,7 +339,7 @@ describe('OSXAdapter', () => {
           ])).to.be.ok();
 
           expect(proc.spawn.calledWith('open', [
-            '-a', OSXAdapter.installPath, '--args', '--plugin-launch', '--channel=autocomplete-python',
+            '-a', OSXAdapter.installPath, '--args', '--plugin-launch-with-copilot', '--channel=autocomplete-python',
           ], customEnv(process.env, null, ['ELECTRON_RUN_AS_NODE']))).to.be.ok();
         });
       });

--- a/test/support/windows.test.js
+++ b/test/support/windows.test.js
@@ -45,7 +45,7 @@ describe('WindowsAdapter', () => {
           unlinkSpy = sinon.stub(fs, 'unlinkSync');
           commandsRestore = fakeCommands({
             exec: {
-              [`"${WindowsAdapter.KITE_INSTALLER_PATH}"` + ' --skip-onboarding --plugin-launch --channel=autocomplete-python']: () => 0,
+              [`"${WindowsAdapter.KITE_INSTALLER_PATH}"` + ' --skip-onboarding --plugin-launch-with-copilot --channel=autocomplete-python']: () => 0,
             },
             del: () => 0,
           });
@@ -91,7 +91,7 @@ describe('WindowsAdapter', () => {
         unlinkSpy = sinon.stub(fs, 'unlinkSync');
         commandsRestore = fakeCommands({
           exec: {
-            [`"${WindowsAdapter.KITE_INSTALLER_PATH}"` + ' --skip-onboarding --plugin-launch --channel=autocomplete-python']: () => 0,
+            [`"${WindowsAdapter.KITE_INSTALLER_PATH}"` + ' --skip-onboarding --plugin-launch-with-copilot --channel=autocomplete-python']: () => 0,
           },
         });
       });
@@ -124,7 +124,7 @@ describe('WindowsAdapter', () => {
       beforeEach(() => {
         commandsRestore = fakeCommands({
           exec: {
-            [`"${WindowsAdapter.KITE_INSTALLER_PATH}"` + ' --skip-onboarding --plugin-launch']: () => 1,
+            [`"${WindowsAdapter.KITE_INSTALLER_PATH}"` + ' --skip-onboarding --plugin-launch-with-copilot']: () => 1,
           },
         });
       });
@@ -145,7 +145,7 @@ describe('WindowsAdapter', () => {
         });
         commandsRestore = fakeCommands({
           exec: {
-            [`"${WindowsAdapter.KITE_INSTALLER_PATH}"` + ' --skip-onboarding --plugin-launch']: () => 0,
+            [`"${WindowsAdapter.KITE_INSTALLER_PATH}"` + ' --skip-onboarding --plugin-launch-with-copilot']: () => 0,
           },
         });
       });


### PR DESCRIPTION
This will launch kited with the Copilot setup workflow. It uses the flag `--plugin-launch-with-copilot` which is added by https://github.com/kiteco/kiteco/pull/8549 . Ideally that PR should have been released when this PR is tested.

cc @its-dhung 

