### PR TITLE
Linux: Shown download progress early

### DIFF
--- a/lib/support/linux.js
+++ b/lib/support/linux.js
@@ -126,15 +126,20 @@ const LinuxSupport = {
 
   downloadKite(url, opts) {
     opts = opts || {};
-    return this.downloadKiteInstallerScript(url)
+    return this.downloadKiteInstallerScript(url, opts.onDownloadProgress)
     .then(() => this.streamKiteDownload(this.downloadPath, opts.onDownloadProgress))
     .then(() => utils.guardCall(opts.onDownload))
     .then(() => opts.install && this.installKite(opts));
   },
 
-  downloadKiteInstallerScript(url) {
+  downloadKiteInstallerScript(url, progress) {
     const req = https.request(url);
     req.end();
+
+    // set download status as early as possible to display the progress bar
+    if (progress) {
+      progress(0, 100, 0);
+    }
 
     return utils.followRedirections(req)
     .then(resp => {


### PR DESCRIPTION
Set download progress to 0% before downloading kite-installer to render the progress bar earyly in ACP. 0% is rendered as an undefined progress in Atom/ACP.