### PR TITLE
acp: new parameter to define if copilot should be started or not

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -148,12 +148,12 @@ module.exports = {
         })));
   },
 
-  runKite() {
-    return this.adapter.runKite();
+  runKite(openCopilot) {
+    return this.adapter.runKite(openCopilot);
   },
 
-  runKiteAndWait(attempts, interval) {
-    return this.runKite().then(() => this.waitForKite(attempts, interval));
+  runKiteAndWait(attempts, interval, openCopilot) {
+    return this.runKite(openCopilot).then(() => this.waitForKite(attempts, interval));
   },
 
   isKiteReachable() {

--- a/lib/support/linux.js
+++ b/lib/support/linux.js
@@ -244,7 +244,7 @@ const LinuxSupport = {
           throw new Error('kited is not installed');
         }
 
-        const kiteArgs = openCopilot
+        const kiteArgs = openCopilot !== false
           ? ['--plugin-launch-with-copilot', '--channel=autocomplete-python']
           : ['--plugin-launch', '--channel=autocomplete-python'];
         child_process.spawn(this.installPath, kiteArgs, {detached: true, stdio: 'ignore', env});

--- a/lib/support/linux.js
+++ b/lib/support/linux.js
@@ -233,20 +233,21 @@ const LinuxSupport = {
     });
   },
 
-  runKite() {
+  runKite(openCopilot) {
     return this.isKiteRunning()
     .catch(() => {
       const env = Object.assign({}, process.env);
-      env.SKIP_KITE_ONBOARDING = '1';
       delete env['ELECTRON_RUN_AS_NODE'];
 
       try {
         if (!fs.existsSync(this.installPath)) {
           throw new Error('kited is not installed');
         }
-        child_process.spawn(this.installPath,
-        ['--plugin-launch-with-copilot', '--channel=autocomplete-python'],
-        {detached: true, stdio: 'ignore', env});
+
+        const kiteArgs = openCopilot
+          ? ['--plugin-launch-with-copilot', '--channel=autocomplete-python']
+          : ['--plugin-launch', '--channel=autocomplete-python'];
+        child_process.spawn(this.installPath, kiteArgs, {detached: true, stdio: 'ignore', env});
       } catch (e) {
         throw new KiteProcessError('kited_error',
         {

--- a/lib/support/osx.js
+++ b/lib/support/osx.js
@@ -221,9 +221,13 @@ const OSXSupport = {
     });
   },
 
-  runKite() {
+  runKite(openCopilot) {
     const env = Object.assign({}, process.env);
     delete env['ELECTRON_RUN_AS_NODE'];
+
+    const kiteArgs = openCopilot
+      ? ['--plugin-launch-with-copilot', '--channel=autocomplete-python']
+      : ['--plugin-launch', '--channel=autocomplete-python'];
 
     return this.isKiteRunning()
     .catch(() => utils.spawnPromise(
@@ -234,7 +238,7 @@ const OSXSupport = {
     .then(() =>
     utils.spawnPromise(
       'open',
-      ['-a', this.installPath, '--args', '--plugin-launch-with-copilot', '--channel=autocomplete-python'],
+      ['-a', this.installPath, '--args', ...kiteArgs],
       { env: env },
       'open_error',
       'Unable to run the open command to start Kite'

--- a/lib/support/osx.js
+++ b/lib/support/osx.js
@@ -225,7 +225,7 @@ const OSXSupport = {
     const env = Object.assign({}, process.env);
     delete env['ELECTRON_RUN_AS_NODE'];
 
-    const kiteArgs = openCopilot
+    const kiteArgs = openCopilot !== false
       ? ['--plugin-launch-with-copilot', '--channel=autocomplete-python']
       : ['--plugin-launch', '--channel=autocomplete-python'];
 

--- a/lib/support/windows.js
+++ b/lib/support/windows.js
@@ -231,7 +231,7 @@ const WindowsSupport = {
         env.KITE_SKIP_ONBOARDING = '1';
       }
 
-      const kiteArgs = openCopilot
+      const kiteArgs = openCopilot !== false
         ? ['--plugin-launch-with-copilot', '--channel=autocomplete-python']
         : ['--plugin-launch', '--channel=autocomplete-python'];
 

--- a/lib/support/windows.js
+++ b/lib/support/windows.js
@@ -222,17 +222,23 @@ const WindowsSupport = {
     });
   },
 
-  runKite() {
+  runKite(openCopilot) {
     return this.isKiteRunning()
     .catch(() => {
       var env = Object.create(process.env);
-      env.KITE_SKIP_ONBOARDING = '1';
       delete env["ELECTRON_RUN_AS_NODE"];
+      if (!openCopilot){
+        env.KITE_SKIP_ONBOARDING = '1';
+      }
+
+      const kiteArgs = openCopilot
+        ? ['--plugin-launch-with-copilot', '--channel=autocomplete-python']
+        : ['--plugin-launch', '--channel=autocomplete-python'];
 
       try {
         child_process.spawn(
           this.KITE_EXE_PATH,
-          ['--plugin-launch-with-copilot', '--channel=autocomplete-python'],
+          kiteArgs,
           {detached: true, env: env});
       } catch (err) {
         throw new KiteProcessError('kite_exe_error',


### PR DESCRIPTION
new parameter `openCopilot` to define if copilot should be launched by kited or not.
Needed for https://github.com/kiteco/kite-installer/pull/87