### PR TITLE
split runKite & runKiteWithCopilot

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,20 @@ KiteConnector.canRunKite()
 })
 ```
 
+#### .runKiteWithCopilot()
+
+Starts an already installed Kite, opens the Copilot, and returns a promise that will resolve if Kite have been successfully started. The operation is delegated to the underlying adapter object which will handle OS specific operations.
+
+```js
+KiteConnector.runKiteWithCopilot()
+.then(() => {
+  // Kite is running but not necessarily reachable
+})
+.catch(() => {
+  // Kite couldn't be started
+})
+```
+
 #### .runKite()
 
 Starts an already installed Kite and returns a promise that will resolve if Kite have been successfully started. The operation is delegated to the underlying adapter object which will handle OS specific operations.

--- a/lib/index.js
+++ b/lib/index.js
@@ -148,6 +148,10 @@ module.exports = {
         })));
   },
 
+  runKiteWithCopilot() {
+    return this.adapter.runKiteWithCopilot();
+  },
+
   runKite() {
     return this.adapter.runKite();
   },

--- a/lib/index.js
+++ b/lib/index.js
@@ -148,12 +148,12 @@ module.exports = {
         })));
   },
 
-  runKite(openCopilot) {
-    return this.adapter.runKite(openCopilot);
+  runKite() {
+    return this.adapter.runKite();
   },
 
-  runKiteAndWait(attempts, interval, openCopilot) {
-    return this.runKite(openCopilot).then(() => this.waitForKite(attempts, interval));
+  runKiteAndWait(attempts, interval) {
+    return this.runKite().then(() => this.waitForKite(attempts, interval));
   },
 
   isKiteReachable() {

--- a/lib/support/linux.js
+++ b/lib/support/linux.js
@@ -233,6 +233,32 @@ const LinuxSupport = {
     });
   },
 
+  runKiteWithCopilot() {
+    const env = Object.assign({}, process.env);
+    env.SKIP_KITE_ONBOARDING = '1';
+    delete env['ELECTRON_RUN_AS_NODE'];
+
+    return new Promise((resolve, reject) => {
+      try {
+        if (!fs.existsSync(this.installPath)) {
+          throw new Error('kited is not installed');
+        }
+        child_process.spawn(this.installPath,
+        ['--plugin-launch-with-copilot', '--channel=autocomplete-python'],
+        {detached: true, stdio: 'ignore', env});
+        resolve();
+      } catch (e) {
+        reject(new KiteProcessError('kited_error',
+        {
+          message: (e.message && e.message === 'kited is not installed') || 'unable to run kited binary',
+          callStack: e.stack,
+          cmd: this.installPath,
+          options: {detached: true, env},
+        }));
+      }
+    });
+  },
+
   runKite() {
     return this.isKiteRunning()
     .catch(() => {

--- a/lib/support/linux.js
+++ b/lib/support/linux.js
@@ -245,7 +245,7 @@ const LinuxSupport = {
           throw new Error('kited is not installed');
         }
         child_process.spawn(this.installPath,
-        ['--plugin-launch-with-copilot', '--channel=autocomplete-python'],
+        ['--plugin-launch', '--channel=autocomplete-python'],
         {detached: true, stdio: 'ignore', env});
       } catch (e) {
         throw new KiteProcessError('kited_error',

--- a/lib/support/linux.js
+++ b/lib/support/linux.js
@@ -233,21 +233,20 @@ const LinuxSupport = {
     });
   },
 
-  runKite(openCopilot) {
+  runKite() {
     return this.isKiteRunning()
     .catch(() => {
       const env = Object.assign({}, process.env);
+      env.SKIP_KITE_ONBOARDING = '1';
       delete env['ELECTRON_RUN_AS_NODE'];
 
       try {
         if (!fs.existsSync(this.installPath)) {
           throw new Error('kited is not installed');
         }
-
-        const kiteArgs = openCopilot !== false
-          ? ['--plugin-launch-with-copilot', '--channel=autocomplete-python']
-          : ['--plugin-launch', '--channel=autocomplete-python'];
-        child_process.spawn(this.installPath, kiteArgs, {detached: true, stdio: 'ignore', env});
+        child_process.spawn(this.installPath,
+        ['--plugin-launch-with-copilot', '--channel=autocomplete-python'],
+        {detached: true, stdio: 'ignore', env});
       } catch (e) {
         throw new KiteProcessError('kited_error',
         {

--- a/lib/support/osx.js
+++ b/lib/support/osx.js
@@ -234,7 +234,7 @@ const OSXSupport = {
     .then(() =>
     utils.spawnPromise(
       'open',
-      ['-a', this.installPath, '--args', '--plugin-launch-with-copilot', '--channel=autocomplete-python'],
+      ['-a', this.installPath, '--args', '--plugin-launch', '--channel=autocomplete-python'],
       { env: env },
       'open_error',
       'Unable to run the open command to start Kite'

--- a/lib/support/osx.js
+++ b/lib/support/osx.js
@@ -221,13 +221,9 @@ const OSXSupport = {
     });
   },
 
-  runKite(openCopilot) {
+  runKite() {
     const env = Object.assign({}, process.env);
     delete env['ELECTRON_RUN_AS_NODE'];
-
-    const kiteArgs = openCopilot !== false
-      ? ['--plugin-launch-with-copilot', '--channel=autocomplete-python']
-      : ['--plugin-launch', '--channel=autocomplete-python'];
 
     return this.isKiteRunning()
     .catch(() => utils.spawnPromise(
@@ -238,7 +234,7 @@ const OSXSupport = {
     .then(() =>
     utils.spawnPromise(
       'open',
-      ['-a', this.installPath, '--args', ...kiteArgs],
+      ['-a', this.installPath, '--args', '--plugin-launch-with-copilot', '--channel=autocomplete-python'],
       { env: env },
       'open_error',
       'Unable to run the open command to start Kite'

--- a/lib/support/osx.js
+++ b/lib/support/osx.js
@@ -221,6 +221,19 @@ const OSXSupport = {
     });
   },
 
+  runKiteWithCopilot() {
+    const env = Object.assign({}, process.env);
+    delete env['ELECTRON_RUN_AS_NODE'];
+
+    return utils.spawnPromise(
+      'open',
+      ['-a', this.installPath, '--args', '--plugin-launch-with-copilot', '--channel=autocomplete-python'],
+      { env: env },
+      'open_error',
+      'Unable to run the open command to start Kite'
+    );
+  },
+
   runKite() {
     const env = Object.assign({}, process.env);
     delete env['ELECTRON_RUN_AS_NODE'];

--- a/lib/support/windows.js
+++ b/lib/support/windows.js
@@ -198,7 +198,7 @@ const WindowsSupport = {
 
     utils.guardCall(opts.onInstallStart);
     return utils.execPromise(
-      `"${this.KITE_INSTALLER_PATH}"` + ' --skip-onboarding --plugin-launch-with-copilot --channel=autocomplete-python',
+      `"${this.KITE_INSTALLER_PATH}"` + ' --skip-onboarding --plugin-launch --channel=autocomplete-python',
       {env: env},
       'kite_install_error',
       'Unable to run Kite installer')
@@ -232,7 +232,7 @@ const WindowsSupport = {
       try {
         child_process.spawn(
           this.KITE_EXE_PATH,
-          ['--plugin-launch-with-copilot', '--channel=autocomplete-python'],
+          ['--plugin-launch', '--channel=autocomplete-python'],
           {detached: true, env: env});
       } catch (err) {
         throw new KiteProcessError('kite_exe_error',

--- a/lib/support/windows.js
+++ b/lib/support/windows.js
@@ -222,6 +222,28 @@ const WindowsSupport = {
     });
   },
 
+  runKiteWithCopilot() {
+    var env = Object.create(process.env);
+    delete env["ELECTRON_RUN_AS_NODE"];
+    return new Promise((resolve, reject) => {
+      try {
+        child_process.spawn(
+          this.KITE_EXE_PATH,
+          ['--plugin-launch-with-copilot', '--channel=autocomplete-python'],
+          {detached: true, env: env});
+        resolve();
+      } catch (err) {
+        reject(new KiteProcessError('kite_exe_error',
+          {
+            message: 'Unable to run kite executable',
+            callStack: err.stack,
+            cmd: this.KITE_EXE_PATH,
+            options: {detached: true, env: env},
+          }));
+      }
+    });
+  },
+
   runKite() {
     return this.isKiteRunning()
     .catch(() => {

--- a/lib/support/windows.js
+++ b/lib/support/windows.js
@@ -222,23 +222,17 @@ const WindowsSupport = {
     });
   },
 
-  runKite(openCopilot) {
+  runKite() {
     return this.isKiteRunning()
     .catch(() => {
       var env = Object.create(process.env);
+      env.KITE_SKIP_ONBOARDING = '1';
       delete env["ELECTRON_RUN_AS_NODE"];
-      if (!openCopilot){
-        env.KITE_SKIP_ONBOARDING = '1';
-      }
-
-      const kiteArgs = openCopilot !== false
-        ? ['--plugin-launch-with-copilot', '--channel=autocomplete-python']
-        : ['--plugin-launch', '--channel=autocomplete-python'];
 
       try {
         child_process.spawn(
           this.KITE_EXE_PATH,
-          kiteArgs,
+          ['--plugin-launch-with-copilot', '--channel=autocomplete-python'],
           {detached: true, env: env});
       } catch (err) {
         throw new KiteProcessError('kite_exe_error',

--- a/test/support/osx.test.js
+++ b/test/support/osx.test.js
@@ -339,7 +339,7 @@ describe('OSXAdapter', () => {
           ])).to.be.ok();
 
           expect(proc.spawn.calledWith('open', [
-            '-a', OSXAdapter.installPath, '--args', '--plugin-launch-with-copilot', '--channel=autocomplete-python',
+            '-a', OSXAdapter.installPath, '--args', '--plugin-launch', '--channel=autocomplete-python',
           ], customEnv(process.env, null, ['ELECTRON_RUN_AS_NODE']))).to.be.ok();
         });
       });

--- a/test/support/windows.test.js
+++ b/test/support/windows.test.js
@@ -45,7 +45,7 @@ describe('WindowsAdapter', () => {
           unlinkSpy = sinon.stub(fs, 'unlinkSync');
           commandsRestore = fakeCommands({
             exec: {
-              [`"${WindowsAdapter.KITE_INSTALLER_PATH}"` + ' --skip-onboarding --plugin-launch-with-copilot --channel=autocomplete-python']: () => 0,
+              [`"${WindowsAdapter.KITE_INSTALLER_PATH}"` + ' --skip-onboarding --plugin-launch --channel=autocomplete-python']: () => 0,
             },
             del: () => 0,
           });
@@ -91,7 +91,7 @@ describe('WindowsAdapter', () => {
         unlinkSpy = sinon.stub(fs, 'unlinkSync');
         commandsRestore = fakeCommands({
           exec: {
-            [`"${WindowsAdapter.KITE_INSTALLER_PATH}"` + ' --skip-onboarding --plugin-launch-with-copilot --channel=autocomplete-python']: () => 0,
+            [`"${WindowsAdapter.KITE_INSTALLER_PATH}"` + ' --skip-onboarding --plugin-launch --channel=autocomplete-python']: () => 0,
           },
         });
       });
@@ -124,7 +124,7 @@ describe('WindowsAdapter', () => {
       beforeEach(() => {
         commandsRestore = fakeCommands({
           exec: {
-            [`"${WindowsAdapter.KITE_INSTALLER_PATH}"` + ' --skip-onboarding --plugin-launch-with-copilot']: () => 1,
+            [`"${WindowsAdapter.KITE_INSTALLER_PATH}"` + ' --skip-onboarding --plugin-launch']: () => 1,
           },
         });
       });
@@ -145,7 +145,7 @@ describe('WindowsAdapter', () => {
         });
         commandsRestore = fakeCommands({
           exec: {
-            [`"${WindowsAdapter.KITE_INSTALLER_PATH}"` + ' --skip-onboarding --plugin-launch-with-copilot']: () => 0,
+            [`"${WindowsAdapter.KITE_INSTALLER_PATH}"` + ' --skip-onboarding --plugin-launch']: () => 0,
           },
         });
       });


### PR DESCRIPTION
1. `runKite` is nominally used by the VS Code & Atom plugins to automatically start Kite when the user edits Python files, if it is not already running, and it needs to start Kite without the copilot
    * this seems slightly broken right now in VS Code, but will be fixed as part of this set of changes.
2. `runKiteWithCopilot` is needed by `kite-installer` to start the Kite copilot for post-install onboarding.