### PR TITLE
Add promise rejection for process errors

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -48,30 +48,30 @@ function hasHeader(header, headers) {
 
 function isRedirection(resp) {
   return resp.statusCode >= 300 &&
-         resp.statusCode < 400 &&
-         hasHeader('location', resp.headers);
+    resp.statusCode < 400 &&
+    hasHeader('location', resp.headers);
 }
 
 // Given a request this function will follow the redirection until a
 // code different that 303 is returned
 function followRedirections(req) {
   return promisifyRequest(req)
-  .then(resp => {
-    if (resp.statusCode >= 200 && resp.statusCode < 300) {
-      return resp;
-    } else if (isRedirection(resp)) {
-      const location = resp.headers.location;
-      const req = request(location);
-      req.end();
-      return followRedirections(req);
-    } else {
-      throw new KiteRequestError('Invalid response status when following redirection', {
-        request: req,
-        response: resp,
-        responseStatus: resp.statusCode,
-      });
-    }
-  });
+    .then(resp => {
+      if (resp.statusCode >= 200 && resp.statusCode < 300) {
+        return resp;
+      } else if (isRedirection(resp)) {
+        const location = resp.headers.location;
+        const req = request(location);
+        req.end();
+        return followRedirections(req);
+      } else {
+        throw new KiteRequestError('Invalid response status when following redirection', {
+          request: req,
+          response: resp,
+          responseStatus: resp.statusCode,
+        });
+      }
+    });
 }
 
 function parseSetCookies(cookies) {
@@ -146,8 +146,8 @@ function handleResponseData(resp, callback) {
 function reversePromise(promise, rejectionMessage, resolutionMessage) {
   return new Promise((resolve, reject) => {
     promise
-    .then(() => reject(rejectionMessage))
-    .catch(() => resolve(resolutionMessage));
+      .then(() => reject(rejectionMessage))
+      .catch(() => resolve(resolutionMessage));
   });
 }
 
@@ -168,7 +168,7 @@ function retryPromise(doAttempt, attempts, interval) {
     };
     setTimeout(() =>
       doAttempt().then(resolve, retryOrReject),
-      n ? interval : 0);
+    n ? interval : 0);
   }
 }
 
@@ -201,10 +201,22 @@ function spawnPromise(cmd, cmdArgs, cmdOptions, rejectionType, rejectionMessage)
     let stdout = '';
     let stderr = '';
 
-    proc.stdout.on('data', data => stdout +=  data);
-    proc.stderr.on('data', data => stdout +=  data);
+    proc.stdout.on('data', data => stdout += data);
+    proc.stderr.on('data', data => stdout += data);
 
     const error = new Error();
+
+    proc.on('error', _ => {
+      reject(new KiteProcessError(rejectionType,
+        {
+          message: rejectionMessage + 'for args: ' + args,
+          stderr,
+          stdout,
+          callStack: error.stack,
+          cmd: `${cmd} ${(typeof cmdOptions != 'string' ? cmdArgs || [] : []).join(' ')}`,
+          options: typeof cmdOptions != 'string' ? cmdOptions : undefined,
+        }));
+    });
 
     proc.on('close', code => {
       code
@@ -228,8 +240,8 @@ function anyPromise(arrayOfPromises) {
   // Record which ones did resolve or reject
   const resolvingPromises = arrayOfPromises.map(promise => {
     return promise
-    .then(result => ({resolve: true, result: result}))
-    .catch(error => ({resolve: false, result: error}));
+      .then(result => ({ resolve: true, result: result }))
+      .catch(error => ({ resolve: false, result: error }));
   });
 
   return Promise.all(resolvingPromises).then(results => {


### PR DESCRIPTION
Add handling and logging @ https://github.com/kiteco/kite-connect-js/compare/proc-err-logging?expand=1#diff-50e3aa130a4f97a42ee2cf111c7b1d9dR209
to help debug the Rollbar issues. Previously, we had no handling in the event that an error occurs when a child process is spawned.