### PR TITLE
read ENOTCONN Handling v2

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,7 @@ const EventEmitter = require('events');
 const utils = require('./utils');
 const KiteStateError = require('./kite-state-error');
 const KiteRequestError = require('./kite-request-error');
-const {STATES} = require('./constants');
+const { STATES } = require('./constants');
 const NodeClient = require('./clients/node');
 const BrowserClient = require('./clients/browser');
 
@@ -45,38 +45,38 @@ module.exports = {
 
   request(options, data, timeout) {
     return this.client.request(options, data, timeout)
-    .catch(() => {
-      let promise = Promise.resolve();
-      if (utils.shouldAddCatchProcessing(options.path)) {
-        promise = promise.then(() => this.isKiteSupported())
-              .then(() => this.isKiteInstalled())
-              .then(() => this.isKiteRunning());
-      }
-      return promise.then(() => {
-        throw new KiteStateError('Kite could not be reached when attempting a request', {
-          state: STATES.UNREACHABLE,
-          request: options,
-          requestData: data,
-        });
-      });
-    })
-    .then(resp => {
-      return resp.statusCode >= 400
-        ? utils.handleResponseData(resp).then(respData => {
-          throw new KiteRequestError('bad_status', {
-            responseStatus: resp.statusCode,
+      .catch(() => {
+        let promise = Promise.resolve();
+        if (utils.shouldAddCatchProcessing(options.path)) {
+          promise = promise.then(() => this.isKiteSupported())
+            .then(() => this.isKiteInstalled())
+            .then(() => this.isKiteRunning());
+        }
+        return promise.then(() => {
+          throw new KiteStateError('Kite could not be reached when attempting a request', {
+            state: STATES.UNREACHABLE,
             request: options,
             requestData: data,
-            response: resp,
-            responseData: respData,
           });
-        })
-        : resp;
-    })
-    .catch(err => {
-      this.emitter.emit('did-fail-request', err);
-      throw err;
-    });
+        });
+      })
+      .then(resp => {
+        return resp.statusCode >= 400
+          ? utils.handleResponseData(resp).then(respData => {
+            throw new KiteRequestError('bad_status', {
+              responseStatus: resp.statusCode,
+              request: options,
+              requestData: data,
+              response: resp,
+              responseData: respData,
+            });
+          })
+          : resp;
+      })
+      .catch(err => {
+        this.emitter.emit('did-fail-request', err);
+        throw err;
+      });
   },
 
   checkHealth() {
@@ -85,16 +85,16 @@ module.exports = {
     };
 
     return this.isKiteSupported()
-    .then(() =>
-      utils.anyPromise([this.isKiteInstalled(), this.isKiteEnterpriseInstalled()]).catch(extractErr))
-    .then(() =>
-      utils.anyPromise([this.isKiteRunning(), this.isKiteEnterpriseRunning()]).catch(extractErr))
-    .then(() => this.isKiteReachable())
-    .then(() => STATES.READY)
-    .catch(err => {
-      if (!err.data || err.data.state == null) { throw err; }
-      return err.data.state;
-    });
+      .then(() =>
+        utils.anyPromise([this.isKiteInstalled()]).catch(extractErr))
+      .then(() =>
+        utils.anyPromise([this.isKiteRunning()]).catch(extractErr))
+      .then(() => this.isKiteReachable())
+      .then(() => STATES.READY)
+      .catch(err => {
+        if (!err.data || err.data.state == null) { throw err; }
+        return err.data.state;
+      });
   },
 
   // FIXME: This method is now deprecated, use checkHealth instead.
@@ -120,11 +120,11 @@ module.exports = {
 
   canInstallKite() {
     return this.isKiteSupported()
-    .then(() =>
-      utils.reversePromise(this.adapter.isKiteInstalled(),
-        new KiteStateError('Kite is already installed', {
-          state: STATES.INSTALLED,
-        })));
+      .then(() =>
+        utils.reversePromise(this.adapter.isKiteInstalled(),
+          new KiteStateError('Kite is already installed', {
+            state: STATES.INSTALLED,
+          })));
   },
 
   installKite(options) {
@@ -141,11 +141,11 @@ module.exports = {
 
   canRunKite() {
     return this.isKiteInstalled()
-    .then(() =>
-      utils.reversePromise(this.isKiteRunning(),
-        new KiteStateError('Kite is already runnning', {
-          state: STATES.RUNNING,
-        })));
+      .then(() =>
+        utils.reversePromise(this.isKiteRunning(),
+          new KiteStateError('Kite is already runnning', {
+            state: STATES.RUNNING,
+          })));
   },
 
   runKiteWithCopilot() {
@@ -181,11 +181,11 @@ module.exports = {
 
   canRunKiteEnterprise() {
     return this.isKiteEnterpriseInstalled()
-    .then(() =>
-      utils.reversePromise(this.isKiteEnterpriseRunning(),
-        new KiteStateError('Kite Enterprise is already runnning', {
-          state: STATES.RUNNING,
-        })));
+      .then(() =>
+        utils.reversePromise(this.isKiteEnterpriseRunning(),
+          new KiteStateError('Kite Enterprise is already runnning', {
+            state: STATES.RUNNING,
+          })));
   },
 
   runKiteEnterprise() {
@@ -229,27 +229,27 @@ module.exports = {
       path: '/clientapi/user',
       method: 'GET',
     })
-    .then((resp) => {
-      switch (resp.statusCode) {
-        case 200:
-          return utils.handleResponseData(resp);
-        case 401:
-          throw new KiteStateError('Kite is not authenticated', {
-            state: STATES.UNLOGGED,
-          });
-        default:
-          return utils.handleResponseData(resp).then(respData => {
-            throw new KiteRequestError('Invalid response status when checking Kite authentication', {
-              responseStatus: resp.statusCode,
-              request: {
-                path: '/clientapi/user',
-                method: 'GET',
-              },
-              response: resp,
-              responseData: respData,
+      .then((resp) => {
+        switch (resp.statusCode) {
+          case 200:
+            return utils.handleResponseData(resp);
+          case 401:
+            throw new KiteStateError('Kite is not authenticated', {
+              state: STATES.UNLOGGED,
             });
-          });
-      }
-    });
+          default:
+            return utils.handleResponseData(resp).then(respData => {
+              throw new KiteRequestError('Invalid response status when checking Kite authentication', {
+                responseStatus: resp.statusCode,
+                request: {
+                  path: '/clientapi/user',
+                  method: 'GET',
+                },
+                response: resp,
+                responseData: respData,
+              });
+            });
+        }
+      });
   },
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -168,7 +168,7 @@ function retryPromise(doAttempt, attempts, interval) {
     };
     setTimeout(() =>
       doAttempt().then(resolve, retryOrReject),
-    n ? interval : 0);
+      n ? interval : 0);
   }
 }
 
@@ -200,35 +200,32 @@ function spawnPromise(cmd, cmdArgs, cmdOptions, rejectionType, rejectionMessage)
     const proc = child_process.spawn(...args);
     let stdout = '';
     let stderr = '';
+    const processErr = (err) => {
+      return new KiteProcessError(rejectionType,
+        {
+          message: rejectionMessage + ' for args: ' + args.join(' '),
+          stderr,
+          stdout,
+          callStack: err.stack,
+          cmd: `${cmd} ${(typeof cmdOptions != 'string' ? cmdArgs || [] : []).join(' ')}`,
+          options: typeof cmdOptions != 'string' ? cmdOptions : undefined,
+        });
+    };
 
     proc.stdout.on('data', data => stdout += data);
     proc.stderr.on('data', data => stdout += data);
+    proc.stdout.on('error', err => reject(processErr(err)));
+    proc.stderr.on('error', err => reject(processErr(err)));
 
     const error = new Error();
 
-    proc.on('error', _ => {
-      reject(new KiteProcessError(rejectionType,
-        {
-          message: rejectionMessage + 'for args: ' + args,
-          stderr,
-          stdout,
-          callStack: error.stack,
-          cmd: `${cmd} ${(typeof cmdOptions != 'string' ? cmdArgs || [] : []).join(' ')}`,
-          options: typeof cmdOptions != 'string' ? cmdOptions : undefined,
-        }));
+    proc.on('error', err => {
+      reject(processErr(err));
     });
 
     proc.on('close', code => {
       code
-        ? reject(new KiteProcessError(rejectionType,
-          {
-            message: rejectionMessage,
-            stderr,
-            stdout,
-            callStack: error.stack,
-            cmd: `${cmd} ${(typeof cmdOptions != 'string' ? cmdArgs || [] : []).join(' ')}`,
-            options: typeof cmdOptions != 'string' ? cmdOptions : undefined,
-          }))
+        ? reject(processErr(error))
         : resolve(stdout);
     });
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,21 +5,21 @@
   "requires": true,
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
-      "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+      "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.0.0"
+        "@babel/highlight": "^7.8.3"
       }
     },
     "@babel/generator": {
-      "version": "7.7.7",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.7.tgz",
-      "integrity": "sha512-/AOIBpHh/JU1l0ZFS4kiRCBnLi6OTHzh0RPk3h9isBxkkqELtQNFi1Vr/tiG9p1yfoUdKVwISuXWQR+hwwM4VQ==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.4.tgz",
+      "integrity": "sha512-PwhclGdRpNAf3IxZb0YVuITPZmmrXz9zf6fH8lT4XbrmfQKr6ryBzhv593P5C6poJRciFCL/eHGW2NuGrgEyxA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.7.4",
+        "@babel/types": "^7.8.3",
         "jsesc": "^2.5.1",
         "lodash": "^4.17.13",
         "source-map": "^0.5.0"
@@ -34,38 +34,38 @@
       }
     },
     "@babel/helper-function-name": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.4.tgz",
-      "integrity": "sha512-AnkGIdiBhEuiwdoMnKm7jfPfqItZhgRaZfMg1XX3bS25INOnLPjPG1Ppnajh8eqgt5kPJnfqrRHqFqmjKDZLzQ==",
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
+      "integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "^7.7.4",
-        "@babel/template": "^7.7.4",
-        "@babel/types": "^7.7.4"
+        "@babel/helper-get-function-arity": "^7.8.3",
+        "@babel/template": "^7.8.3",
+        "@babel/types": "^7.8.3"
       }
     },
     "@babel/helper-get-function-arity": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.4.tgz",
-      "integrity": "sha512-QTGKEdCkjgzgfJ3bAyRwF4yyT3pg+vDgan8DSivq1eS0gwi+KGKE5x8kRcbeFTb/673mkO5SN1IZfmCfA5o+EA==",
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
+      "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.7.4"
+        "@babel/types": "^7.8.3"
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.4.tgz",
-      "integrity": "sha512-guAg1SXFcVr04Guk9eq0S4/rWS++sbmyqosJzVs8+1fH5NI+ZcmkaSkc7dmtAFbHFva6yRJnjW3yAcGxjueDug==",
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
+      "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.7.4"
+        "@babel/types": "^7.8.3"
       }
     },
     "@babel/highlight": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
-      "integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
+      "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
       "dev": true,
       "requires": {
         "chalk": "^2.0.0",
@@ -111,34 +111,34 @@
       }
     },
     "@babel/parser": {
-      "version": "7.7.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.7.tgz",
-      "integrity": "sha512-WtTZMZAZLbeymhkd/sEaPD8IQyGAhmuTuvTzLiCFM7iXiVdY0gc0IaI+cW0fh1BnSMbJSzXX6/fHllgHKwHhXw==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.4.tgz",
+      "integrity": "sha512-0fKu/QqildpXmPVaRBoXOlyBb3MC+J0A66x97qEfLOMkn3u6nfY5esWogQwi/K0BjASYy4DbnsEWnpNL6qT5Mw==",
       "dev": true
     },
     "@babel/template": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.4.tgz",
-      "integrity": "sha512-qUzihgVPguAzXCK7WXw8pqs6cEwi54s3E+HrejlkuWO6ivMKx9hZl3Y2fSXp9i5HgyWmj7RKP+ulaYnKM4yYxw==",
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.3.tgz",
+      "integrity": "sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.7.4",
-        "@babel/types": "^7.7.4"
+        "@babel/code-frame": "^7.8.3",
+        "@babel/parser": "^7.8.3",
+        "@babel/types": "^7.8.3"
       }
     },
     "@babel/traverse": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.4.tgz",
-      "integrity": "sha512-P1L58hQyupn8+ezVA2z5KBm4/Zr4lCC8dwKCMYzsa5jFMDMQAzaBNy9W5VjB+KAmBjb40U7a/H6ao+Xo+9saIw==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.4.tgz",
+      "integrity": "sha512-NGLJPZwnVEyBPLI+bl9y9aSnxMhsKz42so7ApAv9D+b4vAFPpY013FTS9LdKxcABoIYFU52HcYga1pPlx454mg==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.5.5",
-        "@babel/generator": "^7.7.4",
-        "@babel/helper-function-name": "^7.7.4",
-        "@babel/helper-split-export-declaration": "^7.7.4",
-        "@babel/parser": "^7.7.4",
-        "@babel/types": "^7.7.4",
+        "@babel/code-frame": "^7.8.3",
+        "@babel/generator": "^7.8.4",
+        "@babel/helper-function-name": "^7.8.3",
+        "@babel/helper-split-export-declaration": "^7.8.3",
+        "@babel/parser": "^7.8.4",
+        "@babel/types": "^7.8.3",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
         "lodash": "^4.17.13"
@@ -168,9 +168,9 @@
       }
     },
     "@babel/types": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
-      "integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
+      "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
       "dev": true,
       "requires": {
         "esutils": "^2.0.2",
@@ -233,12 +233,12 @@
       }
     },
     "ajv": {
-      "version": "6.10.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
-      "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.11.0.tgz",
+      "integrity": "sha512-nCprB/0syFYy9fVYU1ox1l2KN8S9I+tziH8D4zdZuLT3N6RMlGSGt5FSTpAiHB/Whv8Qs1cWHma1aMKZyaHRKA==",
       "dev": true,
       "requires": {
-        "fast-deep-equal": "^2.0.1",
+        "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
@@ -380,9 +380,9 @@
       "dev": true
     },
     "aws4": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.0.tgz",
-      "integrity": "sha512-Uvq6hVe90D0B2WEnUqtdgY1bATGz3mw33nH9Y+dmA+w5DHvUmBgkr5rM/KCHpCsiFNRUfokW/szpPPgMK2hm4A==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
+      "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==",
       "dev": true
     },
     "babel-code-frame": {
@@ -954,9 +954,9 @@
       }
     },
     "es-abstract": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0.tgz",
-      "integrity": "sha512-yYkE07YF+6SIBmg1MsJ9dlub5L48Ek7X0qz+c/CPCHS9EBXfESorzng4cJQjJW5/pB6vDF41u7F8vUhLVDqIug==",
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.4.tgz",
+      "integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
       "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.1",
@@ -1079,24 +1079,16 @@
       "dev": true
     },
     "escodegen": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.12.0.tgz",
-      "integrity": "sha512-TuA+EhsanGcme5T3R0L80u4t8CpbXQjegRmf7+FPTJrtCTErXFeelblRgHQa1FofEzqYYJmJ/OqjTwREp9qgmg==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.1.tgz",
+      "integrity": "sha512-Bmt7NcRySdIfNPfU2ZoXDrrXsG9ZjvDxcAlMfDUgRBjLOWTuIACXPBFJH7Z+cLb40JeQco5toikyc9t9P8E9SQ==",
       "dev": true,
       "requires": {
-        "esprima": "^3.1.3",
+        "esprima": "^4.0.1",
         "estraverse": "^4.2.0",
         "esutils": "^2.0.2",
         "optionator": "^0.8.1",
         "source-map": "~0.6.1"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
-          "dev": true
-        }
       }
     },
     "escope": {
@@ -1598,9 +1590,9 @@
       "dev": true
     },
     "esquery": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
-      "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.1.0.tgz",
+      "integrity": "sha512-MxYW9xKmROWF672KqjO75sszsA8Mxhw06YFeS5VHlB98KDHbOSurm3ArsjO60Eaf3QmGMCP1yn+0JQkNLo/97Q==",
       "dev": true,
       "requires": {
         "estraverse": "^4.0.0"
@@ -1711,9 +1703,9 @@
       }
     },
     "fast-deep-equal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
+      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
       "dev": true
     },
     "fast-json-stable-stringify": {
@@ -1976,6 +1968,7 @@
         "lodash._reescape": "^3.0.0",
         "lodash._reevaluate": "^3.0.0",
         "lodash._reinterpolate": "^3.0.0",
+        "lodash.template": "^3.0.0",
         "minimist": "^1.1.0",
         "multipipe": "^0.1.2",
         "object-assign": "^3.0.0",
@@ -2005,18 +1998,6 @@
       "dev": true,
       "requires": {
         "glogg": "^1.0.0"
-      }
-    },
-    "handlebars": {
-      "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
-      "integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
-      "dev": true,
-      "requires": {
-        "neo-async": "^2.6.0",
-        "optimist": "^0.6.1",
-        "source-map": "^0.6.1",
-        "uglify-js": "^3.1.4"
       }
     },
     "har-schema": {
@@ -2103,6 +2084,12 @@
       "requires": {
         "whatwg-encoding": "^1.0.1"
       }
+    },
+    "html-escaper": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.0.tgz",
+      "integrity": "sha512-a4u9BeERWGu/S8JiWEAQcdrg9v4QArtP9keViQjGMdff20fBdd8waotXaNmODqBe6uZ3Nafi7K/ho4gCQHV3Ig==",
+      "dev": true
     },
     "http-signature": {
       "version": "1.2.0",
@@ -2448,12 +2435,12 @@
       }
     },
     "istanbul-reports": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.6.tgz",
-      "integrity": "sha512-SKi4rnMyLBKe0Jy2uUdx28h8oG7ph2PPuQPvIAh31d+Ci+lSiEu4C+h3oBPuJ9+mPKhOyW0M8gY4U5NM1WLeXA==",
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.7.tgz",
+      "integrity": "sha512-uu1F/L1o5Y6LzPVSVZXNOoD/KXpJue9aeLRd0sM9uMXfZvzomB0WxVamWb5ue8kA2vVWEmW7EG+A5n3f1kqHKg==",
       "dev": true,
       "requires": {
-        "handlebars": "^4.1.2"
+        "html-escaper": "^2.0.0"
       }
     },
     "js-tokens": {
@@ -2640,6 +2627,36 @@
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
+    "lodash._basecopy": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+      "dev": true
+    },
+    "lodash._basetostring": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+      "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U=",
+      "dev": true
+    },
+    "lodash._basevalues": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
+      "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc=",
+      "dev": true
+    },
+    "lodash._getnative": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+      "dev": true
+    },
+    "lodash._isiterateecall": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+      "dev": true
+    },
     "lodash._reescape": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
@@ -2658,11 +2675,82 @@
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
       "dev": true
     },
+    "lodash._root": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+      "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
+      "dev": true
+    },
+    "lodash.escape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
+      "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
+      "dev": true,
+      "requires": {
+        "lodash._root": "^3.0.0"
+      }
+    },
     "lodash.flattendeep": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
       "dev": true
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+      "dev": true
+    },
+    "lodash.isarray": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+      "dev": true
+    },
+    "lodash.keys": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "dev": true,
+      "requires": {
+        "lodash._getnative": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
+      }
+    },
+    "lodash.restparam": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+      "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
+      "dev": true
+    },
+    "lodash.template": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+      "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
+      "dev": true,
+      "requires": {
+        "lodash._basecopy": "^3.0.0",
+        "lodash._basetostring": "^3.0.0",
+        "lodash._basevalues": "^3.0.0",
+        "lodash._isiterateecall": "^3.0.0",
+        "lodash._reinterpolate": "^3.0.0",
+        "lodash.escape": "^3.0.0",
+        "lodash.keys": "^3.0.0",
+        "lodash.restparam": "^3.0.0",
+        "lodash.templatesettings": "^3.0.0"
+      }
+    },
+    "lodash.templatesettings": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
+      "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
+      "dev": true,
+      "requires": {
+        "lodash._reinterpolate": "^3.0.0",
+        "lodash.escape": "^3.0.0"
+      }
     },
     "lolex": {
       "version": "1.6.0",
@@ -2709,16 +2797,16 @@
       }
     },
     "mime-db": {
-      "version": "1.42.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.42.0.tgz",
-      "integrity": "sha512-UbfJCR4UAVRNgMpfImz05smAXK7+c+ZntjaA26ANtkXLlOe947Aag5zdIcKQULAiF9Cq4WxBi9jUs5zkA84bYQ=="
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
+      "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
     },
     "mime-types": {
-      "version": "2.1.25",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.25.tgz",
-      "integrity": "sha512-5KhStqB5xpTAeGqKBAMgwaYMnQik7teQN4IAzC7npDv6kzeU6prfkR67bc87J1kWMPGkoaZSq1npmexMgkmEVg==",
+      "version": "2.1.26",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
+      "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
       "requires": {
-        "mime-db": "1.42.0"
+        "mime-db": "1.43.0"
       }
     },
     "mimic-fn": {
@@ -2841,12 +2929,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
-      "dev": true
-    },
-    "neo-async": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
-      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
       "dev": true
     },
     "nested-error-stacks": {
@@ -2997,16 +3079,6 @@
       "dev": true,
       "requires": {
         "mimic-fn": "^1.0.0"
-      }
-    },
-    "optimist": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "dev": true,
-      "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
       }
     },
     "optionator": {
@@ -3259,9 +3331,9 @@
       }
     },
     "readable-stream": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
       "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
@@ -3337,9 +3409,9 @@
       "dev": true
     },
     "request": {
-      "version": "2.88.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
       "dev": true,
       "requires": {
         "aws-sign2": "~0.7.0",
@@ -3349,7 +3421,7 @@
         "extend": "~3.0.2",
         "forever-agent": "~0.6.1",
         "form-data": "~2.3.2",
-        "har-validator": "~5.1.0",
+        "har-validator": "~5.1.3",
         "http-signature": "~1.2.0",
         "is-typedarray": "~1.0.0",
         "isstream": "~0.1.2",
@@ -3359,7 +3431,7 @@
         "performance-now": "^2.1.0",
         "qs": "~6.5.2",
         "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.4.3",
+        "tough-cookie": "~2.5.0",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
       },
@@ -3400,9 +3472,9 @@
       }
     },
     "resolve": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.14.1.tgz",
-      "integrity": "sha512-fn5Wobh4cxbLzuHaE+nphztHy43/b++4M6SsGFC2gB8uYwf0C8LcarfCz1un7UTW8OFQg9iNjZ4xpcFVGebDPg==",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
+      "integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
       "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
@@ -3880,21 +3952,13 @@
       "dev": true
     },
     "tough-cookie": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-      "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
       "dev": true,
       "requires": {
-        "psl": "^1.1.24",
-        "punycode": "^1.4.1"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-          "dev": true
-        }
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
       }
     },
     "tr46": {
@@ -3951,26 +4015,6 @@
       "integrity": "sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ==",
       "dev": true
     },
-    "uglify-js": {
-      "version": "3.7.3",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.3.tgz",
-      "integrity": "sha512-7tINm46/3puUA4hCkKYo4Xdts+JDaVC9ZPRcG8Xw9R4nhO/gZgUM3TENq8IF4Vatk8qCig4MzP/c8G4u2BkVQg==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "commander": "~2.20.3",
-        "source-map": "~0.6.1"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.20.3",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-          "dev": true,
-          "optional": true
-        }
-      }
-    },
     "uri-js": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
@@ -4002,9 +4046,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
-      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
       "dev": true
     },
     "validate-npm-package-license": {
@@ -4097,12 +4141,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-      "dev": true
-    },
-    "wordwrap": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
       "dev": true
     },
     "wrap-ansi": {

--- a/test/kite-connector.test.js
+++ b/test/kite-connector.test.js
@@ -6,13 +6,13 @@ const expect = require('expect.js');
 const KiteConnector = require('../lib');
 const BrowserClient = require('../lib/clients/browser');
 const NodeClient = require('../lib/clients/node');
-const {waitsForPromise} = require('./helpers/async');
-const {withKite, withKiteRoutes} = require('./helpers/kite');
-const {fakeResponse} = require('./helpers/http');
+const { waitsForPromise } = require('./helpers/async');
+const { withKite, withKiteRoutes } = require('./helpers/kite');
+const { fakeResponse } = require('./helpers/http');
 
 describe('KiteConnector', () => {
   describe('.canInstallKite()', () => {
-    withKite({supported: false}, () => {
+    withKite({ supported: false }, () => {
       it('returns a rejected promise', () => {
         return waitsForPromise({
           shouldReject: true,
@@ -20,7 +20,7 @@ describe('KiteConnector', () => {
       });
     });
 
-    withKite({installed: true}, () => {
+    withKite({ installed: true }, () => {
       it('returns a rejected promise', () => {
         return waitsForPromise({
           shouldReject: true,
@@ -28,7 +28,7 @@ describe('KiteConnector', () => {
       });
     });
 
-    withKite({installed: false}, () => {
+    withKite({ installed: false }, () => {
       it('returns a resolved promise', () => {
         return waitsForPromise(() => KiteConnector.canInstallKite());
       });
@@ -36,7 +36,7 @@ describe('KiteConnector', () => {
   });
 
   describe('.canRunKite()', () => {
-    withKite({installed: false}, () => {
+    withKite({ installed: false }, () => {
       it('returns a rejected promise', () => {
         return waitsForPromise({
           shouldReject: true,
@@ -44,7 +44,7 @@ describe('KiteConnector', () => {
       });
     });
 
-    withKite({running: true}, () => {
+    withKite({ running: true }, () => {
       it('returns a rejected promise', () => {
         return waitsForPromise({
           shouldReject: true,
@@ -52,7 +52,7 @@ describe('KiteConnector', () => {
       });
     });
 
-    withKite({running: false}, () => {
+    withKite({ running: false }, () => {
       it('returns a resolved promise', () => {
         return waitsForPromise(() => KiteConnector.canRunKite());
       });
@@ -60,7 +60,7 @@ describe('KiteConnector', () => {
   });
 
   describe('.canRunKiteEnterprise()', () => {
-    withKite({installedEnterprise: false}, () => {
+    withKite({ installedEnterprise: false }, () => {
       it('returns a rejected promise', () => {
         return waitsForPromise({
           shouldReject: true,
@@ -68,7 +68,7 @@ describe('KiteConnector', () => {
       });
     });
 
-    withKite({runningEnterprise: true}, () => {
+    withKite({ runningEnterprise: true }, () => {
       it('returns a rejected promise', () => {
         return waitsForPromise({
           shouldReject: true,
@@ -76,7 +76,7 @@ describe('KiteConnector', () => {
       });
     });
 
-    withKite({runningEnterprise: false}, () => {
+    withKite({ runningEnterprise: false }, () => {
       it('returns a resolved promise', () => {
         return waitsForPromise(() => KiteConnector.canRunKiteEnterprise());
       });
@@ -84,22 +84,22 @@ describe('KiteConnector', () => {
   });
 
   describe('.waitForKite()', () => {
-    withKite({reachable: true}, () => {
+    withKite({ reachable: true }, () => {
       it('returns a resolving promise', () => {
         return waitsForPromise(() => KiteConnector.waitForKite(5, 0));
       });
     });
 
-    withKite({reachable: false}, () => {
+    withKite({ reachable: false }, () => {
       beforeEach(() => {
         sinon.spy(KiteConnector, 'isKiteReachable');
       });
 
       it('returns a promise that will be rejected after the specified number of attempts', () => {
-        return waitsForPromise({shouldReject: true}, () => KiteConnector.waitForKite(5, 0))
-        .then(() => {
-          expect(KiteConnector.isKiteReachable.callCount).to.eql(5);
-        });
+        return waitsForPromise({ shouldReject: true }, () => KiteConnector.waitForKite(5, 0))
+          .then(() => {
+            expect(KiteConnector.isKiteReachable.callCount).to.eql(5);
+          });
       });
     });
   });
@@ -107,9 +107,9 @@ describe('KiteConnector', () => {
   [
     ['isKiteInstalled'],
     ['isKiteRunning'],
-    ['installKite', {foo: 'bar'}],
-    ['downloadKiteRelease', {foo: 'bar'}],
-    ['downloadKite', 'http://kite.com', {foo: 'bar'}],
+    ['installKite', { foo: 'bar' }],
+    ['downloadKiteRelease', { foo: 'bar' }],
+    ['downloadKite', 'http://kite.com', { foo: 'bar' }],
     ['runKite'],
     ['isKiteEnterpriseInstalled'],
     ['isKiteEnterpriseRunning'],
@@ -121,7 +121,7 @@ describe('KiteConnector', () => {
 
       withKite({}, () => {
         beforeEach(() => {
-          stub = sinon.stub(KiteConnector.adapter, method).callsFake(() => {});
+          stub = sinon.stub(KiteConnector.adapter, method).callsFake(() => { });
         });
 
         afterEach(() => {
@@ -137,12 +137,12 @@ describe('KiteConnector', () => {
   });
 
   describe('.request()', () => {
-    withKite({supported: false}, () => {
+    withKite({ supported: false }, () => {
       it('returns a rejected promise with the UNSUPPORTED state', () => {
-        return waitsForPromise({shouldReject: true}, () => KiteConnector.request({path: '/foo'}))
-        .then(err => {
-          expect(err.data.state).to.eql(KiteConnector.STATES.UNSUPPORTED);
-        });
+        return waitsForPromise({ shouldReject: true }, () => KiteConnector.request({ path: '/foo' }))
+          .then(err => {
+            expect(err.data.state).to.eql(KiteConnector.STATES.UNSUPPORTED);
+          });
       });
 
       describe('with a onDidFailRequest listener', () => {
@@ -155,168 +155,150 @@ describe('KiteConnector', () => {
         it('unregisters the listener when calling dispose() on the disposable', () => {
           disposable.dispose();
 
-          return waitsForPromise({shouldReject: true}, () => KiteConnector.request({path: '/foo'}))
-          .then(() => {
-            expect(failSpy.called).not.to.be.ok();
-          });
+          return waitsForPromise({ shouldReject: true }, () => KiteConnector.request({ path: '/foo' }))
+            .then(() => {
+              expect(failSpy.called).not.to.be.ok();
+            });
         });
 
         it('notifies the listener of the failure', () => {
-          return waitsForPromise({shouldReject: true}, () => KiteConnector.request({path: '/foo'}))
-          .then(() => {
-            expect(failSpy.called).to.be.ok();
-            expect(failSpy.lastCall.args[0].data.state).to.eql(KiteConnector.STATES.UNSUPPORTED);
-          });
+          return waitsForPromise({ shouldReject: true }, () => KiteConnector.request({ path: '/foo' }))
+            .then(() => {
+              expect(failSpy.called).to.be.ok();
+              expect(failSpy.lastCall.args[0].data.state).to.eql(KiteConnector.STATES.UNSUPPORTED);
+            });
         });
       });
     });
 
-    withKite({supported: true}, () => {
+    withKite({ supported: true }, () => {
       it('returns a rejected promise with the UNINSTALLED state', () => {
-        return waitsForPromise({shouldReject: true}, () => KiteConnector.request({path: '/foo'}))
-        .then(err => {
-          expect(err.data.state).to.eql(KiteConnector.STATES.UNINSTALLED);
-        });
+        return waitsForPromise({ shouldReject: true }, () => KiteConnector.request({ path: '/foo' }))
+          .then(err => {
+            expect(err.data.state).to.eql(KiteConnector.STATES.UNINSTALLED);
+          });
       });
     });
 
-    withKite({installed: true}, () => {
+    withKite({ installed: true }, () => {
       it('returns a rejected promise with the NOT_RUNNING state', () => {
-        return waitsForPromise({shouldReject: true}, () => KiteConnector.request({path: '/foo'}))
-        .then(err => {
-          expect(err.data.state).to.eql(KiteConnector.STATES.NOT_RUNNING);
-        });
+        return waitsForPromise({ shouldReject: true }, () => KiteConnector.request({ path: '/foo' }))
+          .then(err => {
+            expect(err.data.state).to.eql(KiteConnector.STATES.NOT_RUNNING);
+          });
       });
     });
 
-    withKite({running: true}, () => {
+    withKite({ running: true }, () => {
       it('returns a rejected promise with the UNREACHABLE state', () => {
-        return waitsForPromise({shouldReject: true}, () => KiteConnector.request({path: '/foo'}))
-        .then(err => {
-          expect(err.data.state).to.eql(KiteConnector.STATES.UNREACHABLE);
-        });
+        return waitsForPromise({ shouldReject: true }, () => KiteConnector.request({ path: '/foo' }))
+          .then(err => {
+            expect(err.data.state).to.eql(KiteConnector.STATES.UNREACHABLE);
+          });
       });
     });
 
-    withKite({reachable: true}, () => {
+    withKite({ reachable: true }, () => {
       withKiteRoutes([[
         o => o.path === '/foo',
         o => fakeResponse(401, ''),
       ]]);
 
       it('returns a rejected promise with a bad_status', () => {
-        return waitsForPromise({shouldReject: true}, () => KiteConnector.request({path: '/foo'}))
-        .then(err => {
-          expect(err.type).to.eql('bad_status');
-          expect(err.data.responseStatus).to.eql(401);
-          expect(err.data.responseData).to.eql('');
-        });
+        return waitsForPromise({ shouldReject: true }, () => KiteConnector.request({ path: '/foo' }))
+          .then(err => {
+            expect(err.type).to.eql('bad_status');
+            expect(err.data.responseStatus).to.eql(401);
+            expect(err.data.responseData).to.eql('');
+          });
       });
     });
 
-    withKite({reachable: true}, () => {
+    withKite({ reachable: true }, () => {
       withKiteRoutes([[
         o => o.path === '/foo',
         o => fakeResponse(403, ''),
       ]]);
 
       it('returns a rejected promise with a bad_status', () => {
-        return waitsForPromise({shouldReject: true}, () => KiteConnector.request({path: '/foo'}))
-        .then(err => {
-          expect(err.type).to.eql('bad_status');
-          expect(err.data.responseStatus).to.eql(403);
-          expect(err.data.responseData).to.eql('');
-        });
+        return waitsForPromise({ shouldReject: true }, () => KiteConnector.request({ path: '/foo' }))
+          .then(err => {
+            expect(err.type).to.eql('bad_status');
+            expect(err.data.responseStatus).to.eql(403);
+            expect(err.data.responseData).to.eql('');
+          });
       });
     });
 
-    withKite({reachable: true}, () => {
+    withKite({ reachable: true }, () => {
       withKiteRoutes([[
         o => o.path === '/foo',
         o => fakeResponse(404, 'not found'),
       ]]);
 
       it('returns a rejected promise with a bad_status', () => {
-        return waitsForPromise({shouldReject: true}, () => KiteConnector.request({path: '/foo'}))
-        .then(err => {
-          expect(err.type).to.eql('bad_status');
-          expect(err.data.responseStatus).to.eql(404);
-          expect(err.data.responseData).to.eql('not found');
-        });
+        return waitsForPromise({ shouldReject: true }, () => KiteConnector.request({ path: '/foo' }))
+          .then(err => {
+            expect(err.type).to.eql('bad_status');
+            expect(err.data.responseStatus).to.eql(404);
+            expect(err.data.responseData).to.eql('not found');
+          });
       });
     });
 
-    withKite({reachable: true}, () => {
+    withKite({ reachable: true }, () => {
       withKiteRoutes([[
         o => o.path === '/foo',
         o => fakeResponse(200),
       ]]);
 
       it('returns a resolved promise with the response object', () => {
-        return waitsForPromise(() => KiteConnector.request({path: '/foo'}))
-        .then(resp => {
-          expect(resp.statusCode).to.eql(200);
-        });
+        return waitsForPromise(() => KiteConnector.request({ path: '/foo' }))
+          .then(resp => {
+            expect(resp.statusCode).to.eql(200);
+          });
       });
     });
   });
 
   describe('.checkHealth()', () => {
-    withKite({supported: false}, () => {
+    withKite({ supported: false }, () => {
       it('returns a promise resolved with the corresponding state', () => {
         return waitsForPromise(() => KiteConnector.checkHealth())
-        .then(state => {
-          expect(state).to.eql(KiteConnector.STATES.UNSUPPORTED);
-        });
+          .then(state => {
+            expect(state).to.eql(KiteConnector.STATES.UNSUPPORTED);
+          });
       });
     });
 
-    withKite({installed: false}, () => {
+    withKite({ installed: false }, () => {
       it('returns a promise resolved with the corresponding state', () => {
         return waitsForPromise(() => KiteConnector.checkHealth())
-        .then(state => {
-          expect(state).to.eql(KiteConnector.STATES.UNINSTALLED);
-        });
+          .then(state => {
+            expect(state).to.eql(KiteConnector.STATES.UNINSTALLED);
+          });
       });
     });
 
-    withKite({running: false}, () => {
+    withKite({ running: false }, () => {
       it('returns a promise resolved with the corresponding state', () => {
         return waitsForPromise(() => KiteConnector.checkHealth())
-        .then(state => {
-          expect(state).to.eql(KiteConnector.STATES.INSTALLED);
-        });
+          .then(state => {
+            expect(state).to.eql(KiteConnector.STATES.INSTALLED);
+          });
       });
     });
 
-    withKite({installedEnterprise: false}, () => {
+    withKite({ reachable: false }, () => {
       it('returns a promise resolved with the corresponding state', () => {
         return waitsForPromise(() => KiteConnector.checkHealth())
-        .then(state => {
-          expect(state).to.eql(KiteConnector.STATES.UNINSTALLED);
-        });
+          .then(state => {
+            expect(state).to.eql(KiteConnector.STATES.RUNNING);
+          });
       });
     });
 
-    withKite({runningEnterprise: false}, () => {
-      it('returns a promise resolved with the corresponding state', () => {
-        return waitsForPromise(() => KiteConnector.checkHealth())
-        .then(state => {
-          expect(state).to.eql(KiteConnector.STATES.INSTALLED);
-        });
-      });
-    });
-
-    withKite({reachable: false}, () => {
-      it('returns a promise resolved with the corresponding state', () => {
-        return waitsForPromise(() => KiteConnector.checkHealth())
-        .then(state => {
-          expect(state).to.eql(KiteConnector.STATES.RUNNING);
-        });
-      });
-    });
-
-    withKite({reachable: true}, () => {
+    withKite({ reachable: true }, () => {
       withKiteRoutes([[
         o => o.path === '/clientapi/user',
         o => fakeResponse(500),
@@ -328,7 +310,7 @@ describe('KiteConnector', () => {
       });
     });
 
-    withKite({reachable: true}, () => {
+    withKite({ reachable: true }, () => {
       withKiteRoutes([[
         o => o.path === '/clientapi/user',
         o => fakeResponse(200),


### PR DESCRIPTION
Resolves https://github.com/kiteco/kiteco/issues/9708

Realized that in `spawnPromise` we read from `proc.stdout` and `proc.stdin` which are both instances of [`net.Socket`](https://nodejs.org/api/net.html#net_class_net_socket). If there's an error, we fail to reject the promise, resulting in the VSCode rollbar. To fix:

- Add handlers `proc.stdout.on('error'...` and `proc.stderr.on('error'...`
- For good measure, remove calls to check state of Kite Enterprise