### PR TITLE
Enable Plugin Install Flow For VS Code

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -127,8 +127,8 @@ module.exports = {
           })));
   },
 
-  hasKiteConfig() {
-    return this.adapter.hasKiteConfig();
+  hasKiteRun() {
+    return this.adapter.hasKiteRun();
   },
 
   installKite(options) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -127,6 +127,10 @@ module.exports = {
           })));
   },
 
+  hasKiteConfig() {
+    return this.adapter.hasKiteConfig();
+  },
+
   installKite(options) {
     return this.adapter.installKite(options);
   },
@@ -156,7 +160,10 @@ module.exports = {
     return this.adapter.runKite();
   },
 
-  runKiteAndWait(attempts, interval) {
+  runKiteAndWait(attempts, interval, runWithCopilot) {
+    if (runWithCopilot) {
+      return this.runKiteWithCopilot().then(() => this.waitForKite(attempts, interval));
+    }
     return this.runKite().then(() => this.waitForKite(attempts, interval));
   },
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -160,10 +160,7 @@ module.exports = {
     return this.adapter.runKite();
   },
 
-  runKiteAndWait(attempts, interval, runWithCopilot) {
-    if (runWithCopilot) {
-      return this.runKiteWithCopilot().then(() => this.waitForKite(attempts, interval));
-    }
+  runKiteAndWait(attempts, interval) {
     return this.runKite().then(() => this.waitForKite(attempts, interval));
   },
 

--- a/lib/support/linux.js
+++ b/lib/support/linux.js
@@ -217,7 +217,8 @@ const LinuxSupport = {
       .then(() => this.resetInstallPath()) // force recalculation of mem'd path on successful install
       .then(() => utils.guardCall(opts.onMount))
       .then(() => fs.unlinkSync(this.KITE_INSTALLER_PATH))
-      .then(() => utils.guardCall(opts.onRemove));
+      .then(() => utils.guardCall(opts.onRemove))
+      .then(() => opts.launchCopilot && this.runKiteWithCopilot(opts));
   },
 
   isKiteRunning() {
@@ -238,7 +239,11 @@ const LinuxSupport = {
       });
   },
 
-  runKiteWithCopilot() {
+  runKiteWithCopilot(opts) {
+    opts = opts || {};
+    const channel = opts.channel ? opts.channel : 'autocomplete-python'
+    console.log('Install Channel:', channel);
+  
     const env = Object.assign({}, process.env);
     env.SKIP_KITE_ONBOARDING = '1';
     delete env['ELECTRON_RUN_AS_NODE'];
@@ -249,7 +254,7 @@ const LinuxSupport = {
           throw new Error('kited is not installed');
         }
         child_process.spawn(this.installPath,
-          ['--plugin-launch-with-copilot', '--channel=autocomplete-python'],
+          ['--plugin-launch-with-copilot', `--channel=${channel}`],
           {detached: true, stdio: 'ignore', env});
         resolve();
       } catch (e) {

--- a/lib/support/linux.js
+++ b/lib/support/linux.js
@@ -241,8 +241,7 @@ const LinuxSupport = {
 
   runKiteWithCopilot(opts) {
     opts = opts || {};
-    const channel = opts.channel ? opts.channel : 'autocomplete-python'
-    console.log('Install Channel:', channel);
+    const channel = opts.channel ? opts.channel : 'autocomplete-python';
   
     const env = Object.assign({}, process.env);
     env.SKIP_KITE_ONBOARDING = '1';

--- a/lib/support/linux.js
+++ b/lib/support/linux.js
@@ -14,7 +14,7 @@ const {STATES} = require('../constants');
 
 const LinuxSupport = {
   RELEASE_URL: 'https://linux.kite.com/dls/linux/current',
-  CONFIG_PATH: path.join(os.homedir(), '.kite'),
+  KITED_HAS_RUN_PATH: path.join(os.homedir(), '.kite', 'kited_has_run'),
   SESSION_FILE_PATH: path.join(os.homedir(), '.kite', 'session.json'),
   KITE_INSTALLER_PATH: path.join(os.tmpdir(), 'kite-installer.sh'),
   KITED_PATH: path.join(os.homedir(), '.local', 'share', 'kite', 'kited'),
@@ -105,8 +105,8 @@ const LinuxSupport = {
     return this.isOSSupported() && this.isOSVersionSupported();
   },
 
-  hasKiteConfig() {
-    return fs.existsSync(this.CONFIG_PATH);
+  hasKiteRun() {
+    return fs.existsSync(this.KITED_HAS_RUN_PATH);
   },
 
   isKiteInstalled() {

--- a/lib/support/linux.js
+++ b/lib/support/linux.js
@@ -14,6 +14,7 @@ const {STATES} = require('../constants');
 
 const LinuxSupport = {
   RELEASE_URL: 'https://linux.kite.com/dls/linux/current',
+  CONFIG_PATH: path.join(os.homedir(), '.kite'),
   SESSION_FILE_PATH: path.join(os.homedir(), '.kite', 'session.json'),
   KITE_INSTALLER_PATH: path.join(os.tmpdir(), 'kite-installer.sh'),
   KITED_PATH: path.join(os.homedir(), '.local', 'share', 'kite', 'kited'),
@@ -69,12 +70,12 @@ const LinuxSupport = {
     try {
       const user = utils.whoami();
       const adminUsers = String(child_process.execSync('getent group root adm admin sudo'))
-      .split('\n')
-      .map(line => line.substring(line.lastIndexOf(':') + 1))
-      .reduce((acc, val) => {
-        val.split(',').forEach(token => acc.push(token.trim()));
-        return acc;
-      }, []);
+        .split('\n')
+        .map(line => line.substring(line.lastIndexOf(':') + 1))
+        .reduce((acc, val) => {
+          val.split(',').forEach(token => acc.push(token.trim()));
+          return acc;
+        }, []);
       return adminUsers.includes(user);
     } catch (e) {
       // fallback to os.userInfo()
@@ -104,6 +105,10 @@ const LinuxSupport = {
     return this.isOSSupported() && this.isOSVersionSupported();
   },
 
+  hasKiteConfig() {
+    return fs.existsSync(this.CONFIG_PATH);
+  },
+
   isKiteInstalled() {
     return new Promise((resolve, reject) => {
       fs.exists(this.installPath, exists => {
@@ -127,9 +132,9 @@ const LinuxSupport = {
   downloadKite(url, opts) {
     opts = opts || {};
     return this.downloadKiteInstallerScript(url, opts.onDownloadProgress)
-    .then(() => this.streamKiteDownload(this.downloadPath, opts.onDownloadProgress))
-    .then(() => utils.guardCall(opts.onDownload))
-    .then(() => opts.install && this.installKite(opts));
+      .then(() => this.streamKiteDownload(this.downloadPath, opts.onDownloadProgress))
+      .then(() => utils.guardCall(opts.onDownload))
+      .then(() => opts.install && this.installKite(opts));
   },
 
   downloadKiteInstallerScript(url, progress) {
@@ -142,13 +147,13 @@ const LinuxSupport = {
     }
 
     return utils.followRedirections(req)
-    .then(resp => {
-      return utils.promisifyStream(resp.pipe(fs.createWriteStream(this.downloadPath)))
-      .then(() => fs.chmodSync(this.downloadPath, 0o700))
-      .then(() => new Promise((resolve, reject) => {
-        setTimeout(resolve, 100);
-      }));
-    });
+      .then(resp => {
+        return utils.promisifyStream(resp.pipe(fs.createWriteStream(this.downloadPath)))
+          .then(() => fs.chmodSync(this.downloadPath, 0o700))
+          .then(() => new Promise((resolve, reject) => {
+            setTimeout(resolve, 100);
+          }));
+      });
   },
 
   streamKiteDownload(scriptPath, progress) {
@@ -163,14 +168,14 @@ const LinuxSupport = {
             const error = new Error();
 
             reject(new KiteProcessError('kited_error',
-            {
-              message: `Unable to download Kite. Unexpected exit code ${code}.`,
-              stderr: '',
-              stdout: '',
-              callStack: error.stack,
-              cmd: `${scriptPath} --download`,
-              options: ["--download"],
-            }));
+              {
+                message: `Unable to download Kite. Unexpected exit code ${code}.`,
+                stderr: '',
+                stdout: '',
+                callStack: error.stack,
+                cmd: `${scriptPath} --download`,
+                options: ['--download'],
+              }));
           }
         });
 
@@ -207,30 +212,30 @@ const LinuxSupport = {
 
     utils.guardCall(opts.onInstallStart);
     return utils.spawnPromise(this.KITE_INSTALLER_PATH,
-    ['--install'], {shell: true},
-    'kite-installer install error', `unable to install kite with ${this.KITE_INSTALLER_PATH}`)
-    .then(() => this.resetInstallPath()) // force recalculation of mem'd path on successful install
-    .then(() => utils.guardCall(opts.onMount))
-    .then(() => fs.unlinkSync(this.KITE_INSTALLER_PATH))
-    .then(() => utils.guardCall(opts.onRemove));
+      ['--install'], {shell: true},
+      'kite-installer install error', `unable to install kite with ${this.KITE_INSTALLER_PATH}`)
+      .then(() => this.resetInstallPath()) // force recalculation of mem'd path on successful install
+      .then(() => utils.guardCall(opts.onMount))
+      .then(() => fs.unlinkSync(this.KITE_INSTALLER_PATH))
+      .then(() => utils.guardCall(opts.onRemove));
   },
 
   isKiteRunning() {
     return utils.spawnPromise(
-    '/bin/ps',
-    ['-axo', 'pid,command'],
-    {encoding: 'utf-8'},
-    'ps_error',
-    'unable to run the ps command and verify that Kite is running')
-    .then(stdout => {
-      const procs = stdout.split('\n');
+      '/bin/ps',
+      ['-axo', 'pid,command'],
+      {encoding: 'utf-8'},
+      'ps_error',
+      'unable to run the ps command and verify that Kite is running')
+      .then(stdout => {
+        const procs = stdout.split('\n');
 
-      if (!procs.some(p => this.KITED_PROCESS.test(p))) {
-        throw new KiteStateError('Kite process could not be found in the processes list', {
-          state: STATES.NOT_RUNNING,
-        });
-      }
-    });
+        if (!procs.some(p => this.KITED_PROCESS.test(p))) {
+          throw new KiteStateError('Kite process could not be found in the processes list', {
+            state: STATES.NOT_RUNNING,
+          });
+        }
+      });
   },
 
   runKiteWithCopilot() {
@@ -244,45 +249,45 @@ const LinuxSupport = {
           throw new Error('kited is not installed');
         }
         child_process.spawn(this.installPath,
-        ['--plugin-launch-with-copilot', '--channel=autocomplete-python'],
-        {detached: true, stdio: 'ignore', env});
+          ['--plugin-launch-with-copilot', '--channel=autocomplete-python'],
+          {detached: true, stdio: 'ignore', env});
         resolve();
       } catch (e) {
         reject(new KiteProcessError('kited_error',
-        {
-          message: (e.message && e.message === 'kited is not installed') || 'unable to run kited binary',
-          callStack: e.stack,
-          cmd: this.installPath,
-          options: {detached: true, env},
-        }));
+          {
+            message: (e.message && e.message === 'kited is not installed') || 'unable to run kited binary',
+            callStack: e.stack,
+            cmd: this.installPath,
+            options: {detached: true, env},
+          }));
       }
     });
   },
 
   runKite() {
     return this.isKiteRunning()
-    .catch(() => {
-      const env = Object.assign({}, process.env);
-      env.SKIP_KITE_ONBOARDING = '1';
-      delete env['ELECTRON_RUN_AS_NODE'];
+      .catch(() => {
+        const env = Object.assign({}, process.env);
+        env.SKIP_KITE_ONBOARDING = '1';
+        delete env['ELECTRON_RUN_AS_NODE'];
 
-      try {
-        if (!fs.existsSync(this.installPath)) {
-          throw new Error('kited is not installed');
+        try {
+          if (!fs.existsSync(this.installPath)) {
+            throw new Error('kited is not installed');
+          }
+          child_process.spawn(this.installPath,
+            ['--plugin-launch', '--channel=autocomplete-python'],
+            {detached: true, stdio: 'ignore', env});
+        } catch (e) {
+          throw new KiteProcessError('kited_error',
+            {
+              message: (e.message && e.message === 'kited is not installed') || 'unable to run kited binary',
+              callStack: e.stack,
+              cmd: this.installPath,
+              options: {detached: true, env},
+            });
         }
-        child_process.spawn(this.installPath,
-        ['--plugin-launch', '--channel=autocomplete-python'],
-        {detached: true, stdio: 'ignore', env});
-      } catch (e) {
-        throw new KiteProcessError('kited_error',
-        {
-          message: (e.message && e.message === 'kited is not installed') || 'unable to run kited binary',
-          callStack: e.stack,
-          cmd: this.installPath,
-          options: {detached: true, env},
-        });
-      }
-    });
+      });
   },
 
   hasBothKiteInstalled() {
@@ -306,9 +311,9 @@ const LinuxSupport = {
 
   notSupported() {
     return Promise.reject(
-    new KiteStateError('Your platform is currently not supported', {
-      state: STATES.UNSUPPORTED,
-    }));
+      new KiteStateError('Your platform is currently not supported', {
+        state: STATES.UNSUPPORTED,
+      }));
   },
 };
 

--- a/lib/support/linux.js
+++ b/lib/support/linux.js
@@ -178,28 +178,28 @@ const LinuxSupport = {
               }));
           }
         });
+        let last = -1;
+        // Must allow child stdio streams to close in order for the `close` event to be emitted.
+        child.stdout.on('data', chunk => {
+          // chunk is a buffer when used with spawn
+          let line = chunk.toString('utf8');
+          let pattern = /Download: (\d+)\/(\d+)/g;
+          let lastMatch, match;
+          while ((match = pattern.exec(line)) !== null) {
+            lastMatch = match;
+          }
 
-        if (progress) {
-          let last = -1;
-          child.stdout.on('data', chunk => {
-            // chunk is a buffer when used with spawn
-            let line = chunk.toString('utf8');
-            let pattern = /Download: (\d+)\/(\d+)/g;
-            let lastMatch, match;
-            while ((match = pattern.exec(line)) !== null) {
-              lastMatch = match;
-            }
-
-            if (lastMatch) {
-              let received = parseInt(lastMatch[1], 10);
-              let total = parseInt(lastMatch[2], 10);
-              if (received >= 0 && total >= received && received > last) {
-                last = received;
+          if (lastMatch) {
+            let received = parseInt(lastMatch[1], 10);
+            let total = parseInt(lastMatch[2], 10);
+            if (received >= 0 && total >= received && received > last) {
+              last = received;
+              if (progress) {
                 progress(received, total, received / total);
               }
             }
-          });
-        }
+          }
+        });
       } catch (e) {
         console.error(e);
         reject(e);

--- a/lib/support/no-support.js
+++ b/lib/support/no-support.js
@@ -61,6 +61,10 @@ module.exports = {
     return false;
   },
 
+  hasKiteConfig() {
+    return false;
+  },
+
   isKiteInstalled() {
     return this.notSupported();
   },

--- a/lib/support/no-support.js
+++ b/lib/support/no-support.js
@@ -61,7 +61,7 @@ module.exports = {
     return false;
   },
 
-  hasKiteConfig() {
+  hasKiteRun() {
     return false;
   },
 

--- a/lib/support/osx.js
+++ b/lib/support/osx.js
@@ -213,7 +213,8 @@ const OSXSupport = {
       // mdfind takes some time to index the app location, so we need to
       // wait for the install to fully complete. Runs 10 times at 1.5s
       // intervals.
-      .then(() => utils.retryPromise(() => this.isKiteInstalled(), 10, 1500));
+      .then(() => utils.retryPromise(() => this.isKiteInstalled(), 10, 1500))
+      .then(() => opts.launchCopilot && this.runKiteWithCopilot(opts));
   },
 
   isKiteRunning() {
@@ -233,13 +234,16 @@ const OSXSupport = {
       });
   },
 
-  runKiteWithCopilot() {
+  runKiteWithCopilot(opts) {
+    opts = opts || {};
+    const channel = opts.channel ? opts.channel : 'autocomplete-python'
+    console.log('Install Channel:', channel);
     const env = Object.assign({}, process.env);
     delete env['ELECTRON_RUN_AS_NODE'];
 
     return utils.spawnPromise(
       'open',
-      ['-a', this.installPath, '--args', '--plugin-launch-with-copilot', '--channel=autocomplete-python'],
+      ['-a', this.installPath, '--args', '--plugin-launch-with-copilot', `--channel=${channel}`],
       { env: env },
       'open_error',
       'Unable to run the open command to start Kite'

--- a/lib/support/osx.js
+++ b/lib/support/osx.js
@@ -7,17 +7,18 @@ const https = require('https');
 const child_process = require('child_process');
 const utils = require('../utils.js');
 const KiteStateError = require('../kite-state-error');
-const {STATES} = require('../constants');
+const { STATES } = require('../constants');
 
 const OSXSupport = {
   RELEASE_URL: 'https://alpha.kite.com/release/dls/mac/current',
   APPS_PATH: '/Applications/',
   KITE_DMG_PATH: '/tmp/Kite.dmg',
   KITE_VOLUME_PATH: '/Volumes/Kite/',
-  KITE_APP_PATH: {mounted: '/Volumes/Kite/Kite.app', defaultInstalled: '/Applications/Kite.app'},
+  KITE_APP_PATH: { mounted: '/Volumes/Kite/Kite.app', defaultInstalled: '/Applications/Kite.app' },
   KITE_SIDEBAR_PATH: '/Applications/Kite.app/Contents/MacOS/KiteSidebar.app',
   KITE_BUNDLE_ID: 'com.kite.Kite',
   SESSION_FILE_PATH: path.join(os.homedir(), '.kite', 'session.json'),
+  CONFIG_PATH: path.join(os.homedir(), '.kite'),
 
   get releaseURL() {
     return this.RELEASE_URL;
@@ -59,11 +60,11 @@ const OSXSupport = {
     try {
       const user = utils.whoami();
       const adminUsers = String(child_process.execSync('dscacheutil -q group -a name admin'))
-      .split('\n')
-      .filter(l => /^users:/.test(l))[0]
-      .trim()
-      .replace(/users:\s+/, '')
-      .split(/\s/g);
+        .split('\n')
+        .filter(l => /^users:/.test(l))[0]
+        .trim()
+        .replace(/users:\s+/, '')
+        .split(/\s/g);
       return adminUsers.includes(user);
     } catch (e) {
       return false;
@@ -90,19 +91,23 @@ const OSXSupport = {
     return fs.existsSync(this.KITE_APP_PATH.defaultInstalled);
   },
 
+  hasKiteConfig() {
+    return fs.existsSync(this.CONFIG_PATH);
+  },
+
   isKiteInstalled() {
     return utils.spawnPromise(
       'mdfind',
       ['kMDItemCFBundleIdentifier = "com.kite.Kite"'],
       'mdfind_error',
       'Unable to run mdfind and verify that Kite is installed')
-    .then(res => {
-      if ((!res || res.trim() === '') && !this.checkDefaultAppPath()) {
-        throw new KiteStateError('Unable to find Kite application install using mdfind', {
-          state: STATES.UNINSTALLED,
-        });
-      }
-    });
+      .then(res => {
+        if ((!res || res.trim() === '') && !this.checkDefaultAppPath()) {
+          throw new KiteStateError('Unable to find Kite application install using mdfind', {
+            state: STATES.UNINSTALLED,
+          });
+        }
+      });
   },
 
   hasManyKiteInstallation() {
@@ -126,13 +131,13 @@ const OSXSupport = {
       ['kMDItemCFBundleIdentifier = "enterprise.kite.Kite"'],
       'mdfind_error',
       'Unable to run mdfind and verify that kite enterprise is installed')
-    .then(res => {
-      if (!res || res.trim() === '') {
-        throw new KiteStateError('Unable to find Kite Enterprise application install using mdfind', {
-          state: STATES.UNINSTALLED,
-        });
-      }
-    });
+      .then(res => {
+        if (!res || res.trim() === '') {
+          throw new KiteStateError('Unable to find Kite Enterprise application install using mdfind', {
+            state: STATES.UNINSTALLED,
+          });
+        }
+      });
   },
 
   downloadKiteRelease(opts) {
@@ -142,8 +147,8 @@ const OSXSupport = {
   downloadKite(url, opts) {
     opts = opts || {};
     return this.streamKiteDownload(url, opts.onDownloadProgress)
-    .then(() => utils.guardCall(opts.onDownload))
-    .then(() => opts.install && this.installKite(opts));
+      .then(() => utils.guardCall(opts.onDownload))
+      .then(() => opts.install && this.installKite(opts));
   },
 
   streamKiteDownload(url, progress) {
@@ -151,24 +156,24 @@ const OSXSupport = {
     req.end();
 
     return utils.followRedirections(req)
-    .then(resp => {
-      if (progress) {
-        const total = parseInt(resp.headers['content-length'], 10);
-        let length = 0;
+      .then(resp => {
+        if (progress) {
+          const total = parseInt(resp.headers['content-length'], 10);
+          let length = 0;
 
-        resp.on('data', chunk => {
-          length += chunk.length;
-          progress(length, total, length / total);
-        });
-      }
+          resp.on('data', chunk => {
+            length += chunk.length;
+            progress(length, total, length / total);
+          });
+        }
 
-      return utils.promisifyStream(
-        resp.pipe(fs.createWriteStream(this.downloadPath))
-      )
-      .then(() => new Promise((resolve, reject) => {
-        setTimeout(resolve, 100);
-      }));
-    });
+        return utils.promisifyStream(
+          resp.pipe(fs.createWriteStream(this.downloadPath))
+        )
+          .then(() => new Promise((resolve, reject) => {
+            setTimeout(resolve, 100);
+          }));
+      });
   },
 
   installKite(opts) {
@@ -180,45 +185,52 @@ const OSXSupport = {
       ['attach', '-nobrowse', this.KITE_DMG_PATH],
       'mount_error',
       'Unable to mount Kite.dmg')
-    .then(() => utils.guardCall(opts.onMount))
-    .then(() => utils.spawnPromise(
-      'cp',
-      ['-r', this.KITE_APP_PATH.mounted, this.APPS_PATH],
-      'cp_error',
-      'Unable to copy Kite.app in the applications directory'))
-    .then(() => utils.guardCall(opts.onCopy))
-    .then(() => utils.spawnPromise(
-      'hdiutil',
-      ['detach', this.KITE_VOLUME_PATH],
-      'unmount_error',
-      'Unable to unmount Kite.dmg'))
-    .then(() => utils.guardCall(opts.onUnmount))
-    .then(() => utils.spawnPromise(
-      'rm', [this.KITE_DMG_PATH],
-      'rm_error',
-      'Unable to remove Kite.dmg'))
-    .then(() => utils.guardCall(opts.onRemove))
-    // mdfind takes some time to index the app location, so we need to
-    // wait for the install to fully complete. Runs 10 times at 1.5s
-    // intervals.
-    .then(() => utils.retryPromise(() => this.isKiteInstalled(), 10, 1500));
+      .then(() => utils.guardCall(opts.onMount))
+      .then(() => utils.spawnPromise(
+        'cp',
+        ['-R', this.KITE_APP_PATH.mounted, this.APPS_PATH],
+        'cp_error',
+        'Unable to copy Kite.app in the applications directory'))
+      .then(() => utils.guardCall(opts.onCopy))
+      .then(() => {
+        return utils.spawnPromise(
+          'codesign',
+          ['--force', '--deep', '--sign', '-', this.KITE_APP_PATH.defaultInstalled],
+          'codesign_error',
+          `Unable to code sign ${this.KITE_APP_PATH.defaultInstalled}`);
+      })
+      .then(() => utils.spawnPromise(
+        'hdiutil',
+        ['detach', this.KITE_VOLUME_PATH],
+        'unmount_error',
+        'Unable to unmount Kite.dmg'))
+      .then(() => utils.guardCall(opts.onUnmount))
+      .then(() => utils.spawnPromise(
+        'rm', [this.KITE_DMG_PATH],
+        'rm_error',
+        'Unable to remove Kite.dmg'))
+      .then(() => utils.guardCall(opts.onRemove))
+      // mdfind takes some time to index the app location, so we need to
+      // wait for the install to fully complete. Runs 10 times at 1.5s
+      // intervals.
+      .then(() => utils.retryPromise(() => this.isKiteInstalled(), 10, 1500));
   },
 
   isKiteRunning() {
     return utils.spawnPromise(
       '/bin/ps',
       ['-axco', 'command'],
-      {encoding: 'utf8'},
+      { encoding: 'utf8' },
       'ps_error',
       'Unable to run the ps command and verify that Kite is running')
-    .then(stdout => {
-      const procs = stdout.split('\n');
-      if (!procs.some(s => /^Kite$/.test(s))) {
-        throw new KiteStateError('Kite process could not be found in the processes list', {
-          state: STATES.NOT_RUNNING,
-        });
-      }
-    });
+      .then(stdout => {
+        const procs = stdout.split('\n');
+        if (!procs.some(s => /^Kite$/.test(s))) {
+          throw new KiteStateError('Kite process could not be found in the processes list', {
+            state: STATES.NOT_RUNNING,
+          });
+        }
+      });
   },
 
   runKiteWithCopilot() {
@@ -239,36 +251,36 @@ const OSXSupport = {
     delete env['ELECTRON_RUN_AS_NODE'];
 
     return this.isKiteRunning()
-    .catch(() => utils.spawnPromise(
-      'defaults',
-      ['write', 'com.kite.Kite', 'shouldReopenSidebar', '0'],
-      'defaults_error',
-      'Unable to run defaults command')
-    .then(() =>
-    utils.spawnPromise(
-      'open',
-      ['-a', this.installPath, '--args', '--plugin-launch', '--channel=autocomplete-python'],
-      { env: env },
-      'open_error',
-      'Unable to run the open command to start Kite'
-    )));
+      .catch(() => utils.spawnPromise(
+        'defaults',
+        ['write', 'com.kite.Kite', 'shouldReopenSidebar', '0'],
+        'defaults_error',
+        'Unable to run defaults command')
+        .then(() =>
+          utils.spawnPromise(
+            'open',
+            ['-a', this.installPath, '--args', '--plugin-launch', '--channel=autocomplete-python'],
+            { env: env },
+            'open_error',
+            'Unable to run the open command to start Kite'
+          )));
   },
 
   isKiteEnterpriseRunning() {
     return utils.spawnPromise(
       '/bin/ps',
       ['-axco', 'command'],
-      {encoding: 'utf8'},
+      { encoding: 'utf8' },
       'ps_error',
       'Unable to run the ps command and verify that Kite enterprise is running')
-    .then(stdout => {
-      const procs = stdout.split('\n');
-      if (!procs.some(s => /^KiteEnterprise$/.test(s))) {
-        throw new KiteStateError('Kite Enterprise process could not be found in the processes list', {
-          state: STATES.NOT_RUNNING,
-        });
-      }
-    });
+      .then(stdout => {
+        const procs = stdout.split('\n');
+        if (!procs.some(s => /^KiteEnterprise$/.test(s))) {
+          throw new KiteStateError('Kite Enterprise process could not be found in the processes list', {
+            state: STATES.NOT_RUNNING,
+          });
+        }
+      });
   },
 
   runKiteEnterprise() {
@@ -280,13 +292,13 @@ const OSXSupport = {
       ['write', 'enterprise.kite.Kite', 'shouldReopenSidebar', '0'],
       'defaults_error',
       'Unable to run defaults command')
-    .then(() =>
-      utils.spawnPromise(
-        'open',
-        ['-a', this.enterpriseInstallPath],
-        { env: env },
-        'open_error',
-        'Unable to run the open command and start Kite enterprise'));
+      .then(() =>
+        utils.spawnPromise(
+          'open',
+          ['-a', this.enterpriseInstallPath],
+          { env: env },
+          'open_error',
+          'Unable to run the open command and start Kite enterprise'));
   },
 };
 

--- a/lib/support/osx.js
+++ b/lib/support/osx.js
@@ -236,8 +236,8 @@ const OSXSupport = {
 
   runKiteWithCopilot(opts) {
     opts = opts || {};
-    const channel = opts.channel ? opts.channel : 'autocomplete-python'
-    console.log('Install Channel:', channel);
+    const channel = opts.channel ? opts.channel : 'autocomplete-python';
+
     const env = Object.assign({}, process.env);
     delete env['ELECTRON_RUN_AS_NODE'];
 

--- a/lib/support/osx.js
+++ b/lib/support/osx.js
@@ -17,7 +17,7 @@ const OSXSupport = {
   KITE_APP_PATH: { mounted: '/Volumes/Kite/Kite.app', defaultInstalled: '/Applications/Kite.app' },
   KITE_SIDEBAR_PATH: '/Applications/Kite.app/Contents/MacOS/KiteSidebar.app',
   KITE_BUNDLE_ID: 'com.kite.Kite',
-  CONFIG_PATH: path.join(os.homedir(), '.kite'),
+  KITED_HAS_RUN_PATH: path.join(os.homedir(), '.kite', 'kited_has_run'),
   SESSION_FILE_PATH: path.join(os.homedir(), '.kite', 'session.json'),
 
   get releaseURL() {
@@ -91,8 +91,8 @@ const OSXSupport = {
     return fs.existsSync(this.KITE_APP_PATH.defaultInstalled);
   },
 
-  hasKiteConfig() {
-    return fs.existsSync(this.CONFIG_PATH);
+  hasKiteRun() {
+    return fs.existsSync(this.KITED_HAS_RUN_PATH);
   },
 
   isKiteInstalled() {

--- a/lib/support/osx.js
+++ b/lib/support/osx.js
@@ -17,8 +17,8 @@ const OSXSupport = {
   KITE_APP_PATH: { mounted: '/Volumes/Kite/Kite.app', defaultInstalled: '/Applications/Kite.app' },
   KITE_SIDEBAR_PATH: '/Applications/Kite.app/Contents/MacOS/KiteSidebar.app',
   KITE_BUNDLE_ID: 'com.kite.Kite',
-  SESSION_FILE_PATH: path.join(os.homedir(), '.kite', 'session.json'),
   CONFIG_PATH: path.join(os.homedir(), '.kite'),
+  SESSION_FILE_PATH: path.join(os.homedir(), '.kite', 'session.json'),
 
   get releaseURL() {
     return this.RELEASE_URL;

--- a/lib/support/test-adapter.js
+++ b/lib/support/test-adapter.js
@@ -61,7 +61,7 @@ module.exports = (setup) => {
       return setup.supported;
     },
 
-    hasKiteConfig() {
+    hasKiteRun() {
       return false;
     },
 

--- a/lib/support/test-adapter.js
+++ b/lib/support/test-adapter.js
@@ -61,6 +61,10 @@ module.exports = (setup) => {
       return setup.supported;
     },
 
+    hasKiteConfig() {
+      return false;
+    },
+
     isKiteInstalled() {
       return setup.installed
         ? Promise.resolve()

--- a/lib/support/windows.js
+++ b/lib/support/windows.js
@@ -197,19 +197,22 @@ const WindowsSupport = {
 
   installKite(opts) {
     opts = opts || {};
+    const launch = opts.launchCopilot ? '--plugin-launch-with-copilot' : '--plugin-launch';
+    const channel = opts.channel ? opts.channel : 'autocomplete-python';
+    console.log('Install Channel:', channel);
+
     var env = Object.create(process.env);
     env.KITE_SKIP_ONBOARDING = '1';
 
     utils.guardCall(opts.onInstallStart);
     return utils.execPromise(
-      `"${this.KITE_INSTALLER_PATH}"` + ' --skip-onboarding --plugin-launch --channel=autocomplete-python',
+      `"${this.KITE_INSTALLER_PATH}" --skip-onboarding ${launch} --channel=${channel}`,
       {env: env},
       'kite_install_error',
       'Unable to run Kite installer')
       .then(() => utils.guardCall(opts.onCopy))
       .then(() => fs.unlinkSync(this.KITE_INSTALLER_PATH))
-      .then(() => utils.guardCall(opts.onRemove))
-      .then(() => opts.launchCopilot && this.runKiteWithCopilot(opts));
+      .then(() => utils.guardCall(opts.onRemove));
   },
 
   isKiteRunning() {
@@ -229,8 +232,7 @@ const WindowsSupport = {
 
   runKiteWithCopilot(opts) {
     opts = opts || {};
-    const channel = opts.channel ? opts.channel : 'autocomplete-python'
-    console.log('Install Channel:', channel);
+    const channel = opts.channel ? opts.channel : 'autocomplete-python';
 
     var env = Object.create(process.env);
     delete env['ELECTRON_RUN_AS_NODE'];

--- a/lib/support/windows.js
+++ b/lib/support/windows.js
@@ -199,7 +199,6 @@ const WindowsSupport = {
     opts = opts || {};
     const launch = opts.launchCopilot ? '--plugin-launch-with-copilot' : '--plugin-launch';
     const channel = opts.channel ? opts.channel : 'autocomplete-python';
-    console.log('Install Channel:', channel);
 
     var env = Object.create(process.env);
     env.KITE_SKIP_ONBOARDING = '1';

--- a/lib/support/windows.js
+++ b/lib/support/windows.js
@@ -17,7 +17,7 @@ let COMPUTED_INSTALL_PATH;
 const WindowsSupport = {
   RELEASE_URL: 'https://alpha.kite.com/release/dls/windows/current',
   KITE_INSTALLER_PATH: path.join(os.tmpdir(), 'KiteSetup.exe'),
-  CONFIG_PATH: path.join(process.env.LOCALAPPDATA, 'Kite'),
+  KITED_HAS_RUN_PATH: path.join(process.env.LOCALAPPDATA, 'Kite', 'kited_has_run'),
   SESSION_FILE_PATH: path.join(process.env.LOCALAPPDATA, 'Kite', 'session.json'),
 
   // We're only setting the install path in tests
@@ -120,8 +120,8 @@ const WindowsSupport = {
     return this.isOSVersionSupported();
   },
 
-  hasKiteConfig() {
-    return fs.existsSync(this.CONFIG_PATH);
+  hasKiteRun() {
+    return fs.existsSync(this.KITED_HAS_RUN_PATH);
   },
 
   isKiteInstalled() {
@@ -166,8 +166,8 @@ const WindowsSupport = {
   downloadKite(url, opts) {
     opts = opts || {};
     return this.streamKiteDownload(url, opts.onDownloadProgress)
-    .then(() => utils.guardCall(opts.onDownload))
-    .then(() => opts.install && this.installKite(opts));
+      .then(() => utils.guardCall(opts.onDownload))
+      .then(() => opts.install && this.installKite(opts));
   },
 
   streamKiteDownload(url, progress) {
@@ -175,24 +175,24 @@ const WindowsSupport = {
     req.end();
 
     return utils.followRedirections(req)
-    .then(resp => {
-      if (progress) {
-        const total = parseInt(resp.headers['content-length'], 10);
-        let length = 0;
+      .then(resp => {
+        if (progress) {
+          const total = parseInt(resp.headers['content-length'], 10);
+          let length = 0;
 
-        resp.on('data', chunk => {
-          length += chunk.length;
-          progress(length, total, length / total);
-        });
-      }
+          resp.on('data', chunk => {
+            length += chunk.length;
+            progress(length, total, length / total);
+          });
+        }
 
-      return utils.promisifyStream(
-        resp.pipe(fs.createWriteStream(this.downloadPath))
-      )
-      .then(() => new Promise((resolve, reject) => {
-        setTimeout(resolve, 100);
-      }));
-    });
+        return utils.promisifyStream(
+          resp.pipe(fs.createWriteStream(this.downloadPath))
+        )
+          .then(() => new Promise((resolve, reject) => {
+            setTimeout(resolve, 100);
+          }));
+      });
   },
 
   installKite(opts) {
@@ -206,9 +206,9 @@ const WindowsSupport = {
       {env: env},
       'kite_install_error',
       'Unable to run Kite installer')
-    .then(() => utils.guardCall(opts.onCopy))
-    .then(() => fs.unlinkSync(this.KITE_INSTALLER_PATH))
-    .then(() => utils.guardCall(opts.onRemove));
+      .then(() => utils.guardCall(opts.onCopy))
+      .then(() => fs.unlinkSync(this.KITE_INSTALLER_PATH))
+      .then(() => utils.guardCall(opts.onRemove));
   },
 
   isKiteRunning() {
@@ -216,19 +216,19 @@ const WindowsSupport = {
       'tasklist',
       'tasklist_error',
       'Unable to run the tasklist command and verify whether kite is running or not')
-    .then(stdout => {
-      const procs = stdout.split('\n');
-      if (procs.every(l => l.indexOf('kited.exe') === -1)) {
-        throw new KiteStateError('Unable to find kited.exe process in the tasks list', {
-          state: STATES.NOT_RUNNING,
-        });
-      }
-    });
+      .then(stdout => {
+        const procs = stdout.split('\n');
+        if (procs.every(l => l.indexOf('kited.exe') === -1)) {
+          throw new KiteStateError('Unable to find kited.exe process in the tasks list', {
+            state: STATES.NOT_RUNNING,
+          });
+        }
+      });
   },
 
   runKiteWithCopilot() {
     var env = Object.create(process.env);
-    delete env["ELECTRON_RUN_AS_NODE"];
+    delete env['ELECTRON_RUN_AS_NODE'];
     return new Promise((resolve, reject) => {
       try {
         child_process.spawn(
@@ -250,26 +250,26 @@ const WindowsSupport = {
 
   runKite() {
     return this.isKiteRunning()
-    .catch(() => {
-      var env = Object.create(process.env);
-      env.KITE_SKIP_ONBOARDING = '1';
-      delete env["ELECTRON_RUN_AS_NODE"];
+      .catch(() => {
+        var env = Object.create(process.env);
+        env.KITE_SKIP_ONBOARDING = '1';
+        delete env['ELECTRON_RUN_AS_NODE'];
 
-      try {
-        child_process.spawn(
-          this.KITE_EXE_PATH,
-          ['--plugin-launch', '--channel=autocomplete-python'],
-          {detached: true, env: env});
-      } catch (err) {
-        throw new KiteProcessError('kite_exe_error',
-          {
-            message: 'Unable to run kite executable',
-            callStack: err.stack,
-            cmd: this.KITE_EXE_PATH,
-            options: {detached: true, env: env},
-          });
-      }
-    });
+        try {
+          child_process.spawn(
+            this.KITE_EXE_PATH,
+            ['--plugin-launch', '--channel=autocomplete-python'],
+            {detached: true, env: env});
+        } catch (err) {
+          throw new KiteProcessError('kite_exe_error',
+            {
+              message: 'Unable to run kite executable',
+              callStack: err.stack,
+              cmd: this.KITE_EXE_PATH,
+              options: {detached: true, env: env},
+            });
+        }
+      });
   },
 
   isKiteEnterpriseRunning() {

--- a/lib/support/windows.js
+++ b/lib/support/windows.js
@@ -12,12 +12,12 @@ const KiteProcessError = require('../kite-process-error');
 const {STATES} = require('../constants');
 
 const KEY_BAT = `"${path.join(__dirname, 'read-key.bat')}"`;
-const ARCH_BAT = `"${path.join(__dirname, 'read-arch.bat')}"`;
 let COMPUTED_INSTALL_PATH;
 
 const WindowsSupport = {
   RELEASE_URL: 'https://alpha.kite.com/release/dls/windows/current',
   KITE_INSTALLER_PATH: path.join(os.tmpdir(), 'KiteSetup.exe'),
+  CONFIG_PATH: path.join(process.env.LOCALAPPDATA, 'Kite'),
   SESSION_FILE_PATH: path.join(process.env.LOCALAPPDATA, 'Kite', 'session.json'),
 
   // We're only setting the install path in tests
@@ -118,6 +118,10 @@ const WindowsSupport = {
 
   isKiteSupported() {
     return this.isOSVersionSupported();
+  },
+
+  hasKiteConfig() {
+    return fs.existsSync(this.CONFIG_PATH);
   },
 
   isKiteInstalled() {

--- a/lib/support/windows.js
+++ b/lib/support/windows.js
@@ -208,7 +208,8 @@ const WindowsSupport = {
       'Unable to run Kite installer')
       .then(() => utils.guardCall(opts.onCopy))
       .then(() => fs.unlinkSync(this.KITE_INSTALLER_PATH))
-      .then(() => utils.guardCall(opts.onRemove));
+      .then(() => utils.guardCall(opts.onRemove))
+      .then(() => opts.launchCopilot && this.runKiteWithCopilot(opts));
   },
 
   isKiteRunning() {
@@ -226,14 +227,18 @@ const WindowsSupport = {
       });
   },
 
-  runKiteWithCopilot() {
+  runKiteWithCopilot(opts) {
+    opts = opts || {};
+    const channel = opts.channel ? opts.channel : 'autocomplete-python'
+    console.log('Install Channel:', channel);
+
     var env = Object.create(process.env);
     delete env['ELECTRON_RUN_AS_NODE'];
     return new Promise((resolve, reject) => {
       try {
         child_process.spawn(
           this.KITE_EXE_PATH,
-          ['--plugin-launch-with-copilot', '--channel=autocomplete-python'],
+          ['--plugin-launch-with-copilot', `--channel=${channel}`],
           {detached: true, env: env});
         resolve();
       } catch (err) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,23 +5,22 @@
   "requires": true,
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
-      "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+      "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.8.3"
+        "@babel/highlight": "^7.10.4"
       }
     },
     "@babel/generator": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.4.tgz",
-      "integrity": "sha512-PwhclGdRpNAf3IxZb0YVuITPZmmrXz9zf6fH8lT4XbrmfQKr6ryBzhv593P5C6poJRciFCL/eHGW2NuGrgEyxA==",
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.11.tgz",
+      "integrity": "sha512-Ggg6WPOJtSi8yYQvLVjG8F/TlpWDlKx0OpS4Kt+xMQPs5OaGYWy+v1A+1TvxI6sAMGZpKWWoAQ1DaeQbImlItA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.8.3",
+        "@babel/types": "^7.12.11",
         "jsesc": "^2.5.1",
-        "lodash": "^4.17.13",
         "source-map": "^0.5.0"
       },
       "dependencies": {
@@ -34,42 +33,48 @@
       }
     },
     "@babel/helper-function-name": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
-      "integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.11.tgz",
+      "integrity": "sha512-AtQKjtYNolKNi6nNNVLQ27CP6D9oFR6bq/HPYSizlzbp7uC1M59XJe8L+0uXjbIaZaUJF99ruHqVGiKXU/7ybA==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "^7.8.3",
-        "@babel/template": "^7.8.3",
-        "@babel/types": "^7.8.3"
+        "@babel/helper-get-function-arity": "^7.12.10",
+        "@babel/template": "^7.12.7",
+        "@babel/types": "^7.12.11"
       }
     },
     "@babel/helper-get-function-arity": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
-      "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
+      "version": "7.12.10",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.10.tgz",
+      "integrity": "sha512-mm0n5BPjR06wh9mPQaDdXWDoll/j5UpCAPl1x8fS71GHm7HA6Ua2V4ylG1Ju8lvcTOietbPNNPaSilKj+pj+Ag==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.8.3"
+        "@babel/types": "^7.12.10"
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
-      "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.11.tgz",
+      "integrity": "sha512-LsIVN8j48gHgwzfocYUSkO/hjYAOJqlpJEc7tGXcIm4cubjVUf8LGW6eWRyxEu7gA25q02p0rQUWoCI33HNS5g==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.8.3"
+        "@babel/types": "^7.12.11"
       }
     },
+    "@babel/helper-validator-identifier": {
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+      "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+      "dev": true
+    },
     "@babel/highlight": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
-      "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+      "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
       "dev": true,
       "requires": {
+        "@babel/helper-validator-identifier": "^7.10.4",
         "chalk": "^2.0.0",
-        "esutils": "^2.0.2",
         "js-tokens": "^4.0.0"
       },
       "dependencies": {
@@ -111,46 +116,46 @@
       }
     },
     "@babel/parser": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.4.tgz",
-      "integrity": "sha512-0fKu/QqildpXmPVaRBoXOlyBb3MC+J0A66x97qEfLOMkn3u6nfY5esWogQwi/K0BjASYy4DbnsEWnpNL6qT5Mw==",
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.11.tgz",
+      "integrity": "sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg==",
       "dev": true
     },
     "@babel/template": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.3.tgz",
-      "integrity": "sha512-04m87AcQgAFdvuoyiQ2kgELr2tV8B4fP/xJAVUL3Yb3bkNdMedD3d0rlSQr3PegP0cms3eHjl1F7PWlvWbU8FQ==",
+      "version": "7.12.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.7.tgz",
+      "integrity": "sha512-GkDzmHS6GV7ZeXfJZ0tLRBhZcMcY0/Lnb+eEbXDBfCAcZCjrZKe6p3J4we/D24O9Y8enxWAg1cWwof59yLh2ow==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.8.3",
-        "@babel/parser": "^7.8.3",
-        "@babel/types": "^7.8.3"
+        "@babel/code-frame": "^7.10.4",
+        "@babel/parser": "^7.12.7",
+        "@babel/types": "^7.12.7"
       }
     },
     "@babel/traverse": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.4.tgz",
-      "integrity": "sha512-NGLJPZwnVEyBPLI+bl9y9aSnxMhsKz42so7ApAv9D+b4vAFPpY013FTS9LdKxcABoIYFU52HcYga1pPlx454mg==",
+      "version": "7.12.12",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.12.tgz",
+      "integrity": "sha512-s88i0X0lPy45RrLM8b9mz8RPH5FqO9G9p7ti59cToE44xFm1Q+Pjh5Gq4SXBbtb88X7Uy7pexeqRIQDDMNkL0w==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.8.3",
-        "@babel/generator": "^7.8.4",
-        "@babel/helper-function-name": "^7.8.3",
-        "@babel/helper-split-export-declaration": "^7.8.3",
-        "@babel/parser": "^7.8.4",
-        "@babel/types": "^7.8.3",
+        "@babel/code-frame": "^7.12.11",
+        "@babel/generator": "^7.12.11",
+        "@babel/helper-function-name": "^7.12.11",
+        "@babel/helper-split-export-declaration": "^7.12.11",
+        "@babel/parser": "^7.12.11",
+        "@babel/types": "^7.12.12",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
-        "lodash": "^4.17.13"
+        "lodash": "^4.17.19"
       },
       "dependencies": {
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         },
         "globals": {
@@ -168,13 +173,13 @@
       }
     },
     "@babel/types": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.3.tgz",
-      "integrity": "sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==",
+      "version": "7.12.12",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
+      "integrity": "sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==",
       "dev": true,
       "requires": {
-        "esutils": "^2.0.2",
-        "lodash": "^4.17.13",
+        "@babel/helper-validator-identifier": "^7.12.11",
+        "lodash": "^4.17.19",
         "to-fast-properties": "^2.0.0"
       },
       "dependencies": {
@@ -199,9 +204,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-      "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+      "version": "5.7.4",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+      "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
       "dev": true
     },
     "acorn-globals": {
@@ -265,15 +270,15 @@
       }
     },
     "ajv": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.11.0.tgz",
-      "integrity": "sha512-nCprB/0syFYy9fVYU1ox1l2KN8S9I+tziH8D4zdZuLT3N6RMlGSGt5FSTpAiHB/Whv8Qs1cWHma1aMKZyaHRKA==",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "dev": true,
       "requires": {
-        "fast-deep-equal": "^3.1.1",
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
         "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "json-schema-traverse": "^0.3.0"
       }
     },
     "ajv-keywords": {
@@ -370,13 +375,13 @@
       "dev": true
     },
     "array.prototype.find": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.1.0.tgz",
-      "integrity": "sha512-Wn41+K1yuO5p7wRZDl7890c3xvv5UBrfVXTVIe28rSQb6LS0fZMDrQB6PAcxQFRFy6vJTLDc3A2+3CjQdzVKRg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.1.1.tgz",
+      "integrity": "sha512-mi+MYNJYLTx2eNYy+Yh6raoQacCsNeeMUaspFPh9Y141lFSsWxxB8V9mM2ye+eqiRs917J6/pJ4M9ZPzenWckA==",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.13.0"
+        "es-abstract": "^1.17.4"
       }
     },
     "asap": {
@@ -412,9 +417,9 @@
       "dev": true
     },
     "aws4": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
-      "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
+      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
       "dev": true
     },
     "babel-code-frame": {
@@ -549,6 +554,16 @@
         "write-file-atomic": "^2.4.2"
       }
     },
+    "call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      }
+    },
     "caller-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
@@ -611,9 +626,9 @@
       }
     },
     "cli-width": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
+      "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
       "dev": true
     },
     "cliui": {
@@ -680,14 +695,14 @@
       "dev": true
     },
     "codecov": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/codecov/-/codecov-3.7.1.tgz",
-      "integrity": "sha512-JHWxyPTkMLLJn9SmKJnwAnvY09kg2Os2+Ux+GG7LwZ9g8gzDDISpIN5wAsH1UBaafA/yGcd3KofMaorE8qd6Lw==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/codecov/-/codecov-3.8.1.tgz",
+      "integrity": "sha512-Qm7ltx1pzLPsliZY81jyaQ80dcNR4/JpcX0IHCIWrHBXgseySqbdbYfkdiXd7o/xmzQpGRVCKGYeTrHUpn6Dcw==",
       "dev": true,
       "requires": {
         "argv": "0.0.2",
         "ignore-walk": "3.0.3",
-        "js-yaml": "3.13.1",
+        "js-yaml": "3.14.0",
         "teeny-request": "6.0.1",
         "urlgrey": "0.4.4"
       }
@@ -764,20 +779,12 @@
       "dev": true,
       "requires": {
         "safe-buffer": "~5.1.1"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
-        }
       }
     },
     "core-js": {
-      "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-      "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
       "dev": true
     },
     "core-util-is": {
@@ -797,14 +804,6 @@
         "nested-error-stacks": "^2.0.0",
         "pify": "^4.0.1",
         "safe-buffer": "^5.0.1"
-      },
-      "dependencies": {
-        "graceful-fs": {
-          "version": "4.2.3",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-          "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
-          "dev": true
-        }
       }
     },
     "cross-spawn": {
@@ -969,12 +968,23 @@
       "dev": true
     },
     "encoding": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
       "dev": true,
       "requires": {
-        "iconv-lite": "~0.4.13"
+        "iconv-lite": "^0.6.2"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.6.2",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.2.tgz",
+          "integrity": "sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==",
+          "dev": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
+          }
+        }
       }
     },
     "error-ex": {
@@ -987,22 +997,22 @@
       }
     },
     "es-abstract": {
-      "version": "1.17.4",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.4.tgz",
-      "integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+      "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
       "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
         "has-symbols": "^1.0.1",
-        "is-callable": "^1.1.5",
-        "is-regex": "^1.0.5",
-        "object-inspect": "^1.7.0",
+        "is-callable": "^1.2.2",
+        "is-regex": "^1.1.1",
+        "object-inspect": "^1.8.0",
         "object-keys": "^1.1.1",
-        "object.assign": "^4.1.0",
-        "string.prototype.trimleft": "^2.1.1",
-        "string.prototype.trimright": "^2.1.1"
+        "object.assign": "^4.1.1",
+        "string.prototype.trimend": "^1.0.1",
+        "string.prototype.trimstart": "^1.0.1"
       }
     },
     "es-to-primitive": {
@@ -1112,9 +1122,9 @@
       "dev": true
     },
     "escodegen": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.1.tgz",
-      "integrity": "sha512-Bmt7NcRySdIfNPfU2ZoXDrrXsG9ZjvDxcAlMfDUgRBjLOWTuIACXPBFJH7Z+cLb40JeQco5toikyc9t9P8E9SQ==",
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
+      "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
       "dev": true,
       "requires": {
         "esprima": "^4.0.1",
@@ -1182,18 +1192,6 @@
         "text-table": "~0.2.0"
       },
       "dependencies": {
-        "ajv": {
-          "version": "5.5.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-          "dev": true,
-          "requires": {
-            "co": "^4.6.0",
-            "fast-deep-equal": "^1.0.0",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.3.0"
-          }
-        },
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
@@ -1221,19 +1219,13 @@
           }
         },
         "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
           "dev": true,
           "requires": {
             "ms": "^2.1.1"
           }
-        },
-        "fast-deep-equal": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-          "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
-          "dev": true
         },
         "globals": {
           "version": "11.12.0",
@@ -1241,16 +1233,10 @@
           "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
           "dev": true
         },
-        "json-schema-traverse": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-          "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
-          "dev": true
-        },
         "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
           "dev": true
         },
         "strip-ansi": {
@@ -1601,9 +1587,9 @@
       }
     },
     "eslint-visitor-keys": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
-      "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
       "dev": true
     },
     "espree": {
@@ -1623,21 +1609,37 @@
       "dev": true
     },
     "esquery": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.1.0.tgz",
-      "integrity": "sha512-MxYW9xKmROWF672KqjO75sszsA8Mxhw06YFeS5VHlB98KDHbOSurm3ArsjO60Eaf3QmGMCP1yn+0JQkNLo/97Q==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.3.1.tgz",
+      "integrity": "sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==",
       "dev": true,
       "requires": {
-        "estraverse": "^4.0.0"
+        "estraverse": "^5.1.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+          "dev": true
+        }
       }
     },
     "esrecurse": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
-      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "dev": true,
       "requires": {
-        "estraverse": "^4.1.0"
+        "estraverse": "^5.2.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+          "dev": true
+        }
       }
     },
     "estraverse": {
@@ -1684,9 +1686,9 @@
       },
       "dependencies": {
         "type": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/type/-/type-2.0.0.tgz",
-          "integrity": "sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/type/-/type-2.1.0.tgz",
+          "integrity": "sha512-G9absDWvhAWCV2gmF1zKud3OyC61nZDwWvBL2DApaVFogI07CprggiQAOOjvp2NRjYWFzPyu7vwtDrQFq8jeSA==",
           "dev": true
         }
       }
@@ -1727,9 +1729,9 @@
       }
     },
     "fast-deep-equal": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
       "dev": true
     },
     "fast-json-stable-stringify": {
@@ -1816,23 +1818,6 @@
         "graceful-fs": "^4.1.2",
         "rimraf": "~2.6.2",
         "write": "^0.2.1"
-      },
-      "dependencies": {
-        "graceful-fs": {
-          "version": "4.2.3",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-          "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
-          "dev": true
-        },
-        "rimraf": {
-          "version": "2.6.3",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        }
       }
     },
     "foreground-child": {
@@ -1924,6 +1909,17 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
     },
+    "get-intrinsic": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.0.2.tgz",
+      "integrity": "sha512-aeX0vrFm21ILl3+JpFFRNe9aUvp6VFZb2/CTbgLb8j75kOhvoNYjt9d8KA/tJG4gSo8nzEDedRl0h7vDmBYRVg==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      }
+    },
     "getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
@@ -1962,6 +1958,12 @@
         "sparkles": "^1.0.0"
       }
     },
+    "graceful-fs": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+      "dev": true
+    },
     "growl": {
       "version": "1.10.5",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
@@ -1994,12 +1996,6 @@
         "vinyl": "^0.5.0"
       },
       "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        },
         "object-assign": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
@@ -2024,13 +2020,39 @@
       "dev": true
     },
     "har-validator": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
       "dev": true,
       "requires": {
-        "ajv": "^6.5.5",
+        "ajv": "^6.12.3",
         "har-schema": "^2.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+          "dev": true
+        }
       }
     },
     "has": {
@@ -2088,9 +2110,9 @@
       "dev": true
     },
     "hosted-git-info": {
-      "version": "2.8.5",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.5.tgz",
-      "integrity": "sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg==",
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
+      "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
       "dev": true
     },
     "html-encoding-sniffer": {
@@ -2103,9 +2125,9 @@
       }
     },
     "html-escaper": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.0.tgz",
-      "integrity": "sha512-a4u9BeERWGu/S8JiWEAQcdrg9v4QArtP9keViQjGMdff20fBdd8waotXaNmODqBe6uZ3Nafi7K/ho4gCQHV3Ig==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
     },
     "http-proxy-agent": {
@@ -2310,10 +2332,19 @@
       "dev": true
     },
     "is-callable": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
-      "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
+      "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
       "dev": true
+    },
+    "is-core-module": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
+      "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3"
+      }
     },
     "is-date-object": {
       "version": "1.0.2",
@@ -2334,9 +2365,9 @@
       "dev": true
     },
     "is-my-json-valid": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.20.0.tgz",
-      "integrity": "sha512-XTHBZSIIxNsIsZXg7XB5l8z/OBFosl1Wao4tXLpeC7eKU4Vm/kdop2azkPqULwnfGQjmeDIyey9g7afMMtdWAA==",
+      "version": "2.20.5",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.20.5.tgz",
+      "integrity": "sha512-VTPuvvGQtxvCeghwspQu1rBgjYUT6FGxPlvFKbYuFtgc4ADsX3U5ihZOYN0qyU6u+d4X9xXb0IT5O6QpXKt87A==",
       "dev": true,
       "requires": {
         "generate-function": "^2.0.0",
@@ -2346,12 +2377,6 @@
         "xtend": "^4.0.0"
       }
     },
-    "is-promise": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
-      "dev": true
-    },
     "is-property": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
@@ -2359,12 +2384,12 @@
       "dev": true
     },
     "is-regex": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
-      "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
+      "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
       "dev": true,
       "requires": {
-        "has": "^1.0.3"
+        "has-symbols": "^1.0.1"
       }
     },
     "is-resolvable": {
@@ -2414,6 +2439,18 @@
       "requires": {
         "node-fetch": "^1.0.1",
         "whatwg-fetch": ">=0.10.0"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+          "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+          "dev": true,
+          "requires": {
+            "encoding": "^0.1.11",
+            "is-stream": "^1.0.1"
+          }
+        }
       }
     },
     "isstream": {
@@ -2496,12 +2533,12 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         },
         "ms": {
@@ -2509,15 +2546,6 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
-        },
-        "rimraf": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
         }
       }
     },
@@ -2537,9 +2565,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
+      "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -2606,9 +2634,9 @@
       "dev": true
     },
     "json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
       "dev": true
     },
     "json-stable-stringify": {
@@ -2639,9 +2667,9 @@
       "dev": true
     },
     "jsonpointer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.1.0.tgz",
+      "integrity": "sha512-CXcRvMyTlnR53xMcKnuMzfCA5i/nfblTnnr74CZb6C4vG39eu6w51t7nKmU5MfLfbTgGItliNyjO/ciNPDqClg==",
       "dev": true
     },
     "jsprim": {
@@ -2684,12 +2712,6 @@
         "strip-bom": "^3.0.0"
       },
       "dependencies": {
-        "graceful-fs": {
-          "version": "4.2.3",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-          "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
-          "dev": true
-        },
         "pify": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
@@ -2884,16 +2906,16 @@
       }
     },
     "mime-db": {
-      "version": "1.43.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
-      "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
+      "version": "1.45.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.45.0.tgz",
+      "integrity": "sha512-CkqLUxUk15hofLoLyljJSrukZi8mAtgd+yE5uO4tqRZsdsAJKv0O+rFMhVDRJgozy+yG6md5KwuXhD4ocIoP+w=="
     },
     "mime-types": {
-      "version": "2.1.26",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
-      "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
+      "version": "2.1.28",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.28.tgz",
+      "integrity": "sha512-0TO2yJ5YHYr7M2zzT7gDU1tbwHxEUWBCLt0lscSNpcdAfFyJOVEpRYNS7EXVcTLNj/25QO8gulHC5JtTzSE2UQ==",
       "requires": {
-        "mime-db": "1.43.0"
+        "mime-db": "1.45.0"
       }
     },
     "mimic-fn": {
@@ -2912,18 +2934,18 @@
       }
     },
     "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8"
+        "minimist": "^1.2.5"
       }
     },
     "mocha": {
@@ -2966,6 +2988,21 @@
             "minimatch": "^3.0.4",
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
           }
         },
         "supports-color": {
@@ -3031,14 +3068,10 @@
       "dev": true
     },
     "node-fetch": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-      "dev": true,
-      "requires": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
-      }
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "dev": true
     },
     "normalize-package-data": {
       "version": "2.5.0",
@@ -3102,15 +3135,6 @@
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
           "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
           "dev": true
-        },
-        "rimraf": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
         }
       }
     },
@@ -3127,9 +3151,9 @@
       "dev": true
     },
     "object-inspect": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
-      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
+      "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
       "dev": true
     },
     "object-keys": {
@@ -3139,15 +3163,15 @@
       "dev": true
     },
     "object.assign": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
-      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+      "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "function-bind": "^1.1.1",
-        "has-symbols": "^1.0.0",
-        "object-keys": "^1.0.11"
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3",
+        "has-symbols": "^1.0.1",
+        "object-keys": "^1.1.1"
       }
     },
     "once": {
@@ -3195,9 +3219,9 @@
       "dev": true
     },
     "p-limit": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
-      "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
       "dev": true,
       "requires": {
         "p-try": "^2.0.0"
@@ -3228,14 +3252,6 @@
         "hasha": "^3.0.0",
         "lodash.flattendeep": "^4.4.0",
         "release-zalgo": "^1.0.0"
-      },
-      "dependencies": {
-        "graceful-fs": {
-          "version": "4.2.3",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-          "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
-          "dev": true
-        }
       }
     },
     "parse-json": {
@@ -3379,9 +3395,9 @@
       "dev": true
     },
     "psl": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.7.0.tgz",
-      "integrity": "sha512-5NsSEDv8zY70ScRnOTn7bK7eanl2MvFrOrS/R6x+dBt5g1ghnj9Zv90kO8GwT8gxcu2ANyFprnFYB85IogIJOQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
       "dev": true
     },
     "punycode": {
@@ -3430,14 +3446,6 @@
         "safe-buffer": "~5.1.1",
         "string_decoder": "~1.1.1",
         "util-deprecate": "~1.0.1"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
-        }
       }
     },
     "readline2": {
@@ -3559,11 +3567,12 @@
       }
     },
     "resolve": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
-      "integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+      "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
       "dev": true,
       "requires": {
+        "is-core-module": "^2.1.0",
         "path-parse": "^1.0.6"
       }
     },
@@ -3583,14 +3592,20 @@
         "signal-exit": "^3.0.2"
       }
     },
-    "run-async": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
-      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+    "rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
       "dev": true,
       "requires": {
-        "is-promise": "^2.1.0"
+        "glob": "^7.1.3"
       }
+    },
+    "run-async": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+      "dev": true
     },
     "rx-lite": {
       "version": "4.0.8",
@@ -3608,9 +3623,9 @@
       }
     },
     "safe-buffer": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-      "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
     },
     "safer-buffer": {
@@ -3671,9 +3686,9 @@
       "dev": true
     },
     "signal-exit": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
+      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true
     },
     "sinon": {
@@ -3725,23 +3740,12 @@
         "rimraf": "^2.6.2",
         "signal-exit": "^3.0.2",
         "which": "^1.3.0"
-      },
-      "dependencies": {
-        "rimraf": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        }
       }
     },
     "spdx-correct": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
-      "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
+      "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
       "dev": true,
       "requires": {
         "spdx-expression-parse": "^3.0.0",
@@ -3749,15 +3753,15 @@
       }
     },
     "spdx-exceptions": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
-      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
       "dev": true
     },
     "spdx-expression-parse": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
       "dev": true,
       "requires": {
         "spdx-exceptions": "^2.1.0",
@@ -3765,9 +3769,9 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
-      "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.7.tgz",
+      "integrity": "sha512-U+MTEOO0AiDzxwFvoa4JVnMV6mZlJKk2sBLt90s7G0Gd0Mlknc7kxEn3nuDPNZRta7O2uy8oLcZLVT+4sqNZHQ==",
       "dev": true
     },
     "sprintf-js": {
@@ -3829,24 +3833,24 @@
         }
       }
     },
-    "string.prototype.trimleft": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
-      "integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
+    "string.prototype.trimend": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.3.tgz",
+      "integrity": "sha512-ayH0pB+uf0U28CtjlLvL7NaohvR1amUvVZk+y3DYb0Ey2PUV5zPkkKy9+U1ndVEIXO8hNg18eIv9Jntbii+dKw==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.3",
-        "function-bind": "^1.1.1"
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
       }
     },
-    "string.prototype.trimright": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
-      "integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
+    "string.prototype.trimstart": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.3.tgz",
+      "integrity": "sha512-oBIBUy5lea5tt0ovtOFiEQaBkoBBkyJhZXzJYrSmDo5IUUqbOPvVezuRs/agBIdZ2p2Eo1FD6bD9USyBLfl3xg==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.3",
-        "function-bind": "^1.1.1"
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
       }
     },
     "string_decoder": {
@@ -3856,14 +3860,6 @@
       "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
-        }
       }
     },
     "strip-ansi": {
@@ -3919,18 +3915,6 @@
         "string-width": "^2.1.1"
       },
       "dependencies": {
-        "ajv": {
-          "version": "5.5.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-          "dev": true,
-          "requires": {
-            "co": "^4.6.0",
-            "fast-deep-equal": "^1.0.0",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.3.0"
-          }
-        },
         "ansi-styles": {
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -3950,18 +3934,6 @@
             "escape-string-regexp": "^1.0.5",
             "supports-color": "^5.3.0"
           }
-        },
-        "fast-deep-equal": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-          "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
-          "dev": true
-        },
-        "json-schema-traverse": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-          "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
-          "dev": true
         },
         "supports-color": {
           "version": "5.5.0",
@@ -3985,14 +3957,6 @@
         "node-fetch": "^2.2.0",
         "stream-events": "^1.0.5",
         "uuid": "^3.3.2"
-      },
-      "dependencies": {
-        "node-fetch": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
-          "dev": true
-        }
       }
     },
     "test-exclude": {
@@ -4115,15 +4079,15 @@
       "dev": true
     },
     "ua-parser-js": {
-      "version": "0.7.21",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.21.tgz",
-      "integrity": "sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ==",
+      "version": "0.7.23",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.23.tgz",
+      "integrity": "sha512-m4hvMLxgGHXG3O3fQVAyyAQpZzDOvwnhOTjYz5Xmr7r/+LpkNy3vJXdVRWgd1TkAb7NGROZuSy96CrlNVjA7KA==",
       "dev": true
     },
     "uri-js": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
       "requires": {
         "punycode": "^2.1.0"
@@ -4204,9 +4168,9 @@
       }
     },
     "whatwg-fetch": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
-      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.5.0.tgz",
+      "integrity": "sha512-jXkLtsR42xhXg7akoDKvKWE40eJeI+2KZqcp2h3NsOrRnDvtWX36KcKl30dy+hxECivdk2BVUHVNrPtoMBUx6A==",
       "dev": true
     },
     "whatwg-url": {
@@ -4320,14 +4284,6 @@
         "graceful-fs": "^4.1.11",
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.2"
-      },
-      "dependencies": {
-        "graceful-fs": {
-          "version": "4.2.3",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-          "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
-          "dev": true
-        }
       }
     },
     "xml-name-validator": {
@@ -4343,9 +4299,9 @@
       "dev": true
     },
     "y18n": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
+      "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
       "dev": true
     },
     "yallist": {
@@ -4355,9 +4311,9 @@
       "dev": true
     },
     "yargs": {
-      "version": "13.3.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
-      "integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
+      "version": "13.3.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+      "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
       "dev": true,
       "requires": {
         "cliui": "^5.0.0",
@@ -4369,7 +4325,7 @@
         "string-width": "^3.0.0",
         "which-module": "^2.0.0",
         "y18n": "^4.0.0",
-        "yargs-parser": "^13.1.1"
+        "yargs-parser": "^13.1.2"
       },
       "dependencies": {
         "ansi-regex": {

--- a/test/kite-connector.test.js
+++ b/test/kite-connector.test.js
@@ -115,6 +115,7 @@ describe('KiteConnector', () => {
     ['isKiteEnterpriseRunning'],
     ['runKiteEnterprise'],
     ['hasBothKiteInstalled'],
+    ['hasKiteConfig'],
   ].forEach(([method, ...args]) => {
     describe(`.${method}()`, () => {
       let stub;

--- a/test/kite-connector.test.js
+++ b/test/kite-connector.test.js
@@ -115,7 +115,7 @@ describe('KiteConnector', () => {
     ['isKiteEnterpriseRunning'],
     ['runKiteEnterprise'],
     ['hasBothKiteInstalled'],
-    ['hasKiteConfig'],
+    ['hasKiteRun'],
   ].forEach(([method, ...args]) => {
     describe(`.${method}()`, () => {
       let stub;


### PR DESCRIPTION
[Spec](https://kite.quip.com/VGaAAdpgwvnc/Spec-Editor-Plugin-Install-Flow)

- Add check to see if Kite has been installed / run in the past
- Add option `launchCopilot` that can be passed by the plugin. Setting this to true will open the Copilot after installation
- Enable `channel` to be set and sent by the plugin for metrics
- Linux
  - Always read from the child `stdout` stream. This enables the download to proceed even without a `progress` callback.
- OSX
  - Add `codesign --force --deep -sign - `/Applications/Kite.app` into the installation flow. This is needed to be able to launch Kite properly on macOS Big Sur.
